### PR TITLE
Add a pull request template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,9 @@
+## Description
+Linked to Issue: #
+_Add a description of the intent of the changes here_
+
+## Changes
+_List off the code changes contained within this PR_
+
+## Steps to QA
+_Provide steps for reviewers to verify that the code changes achieve the stated intent_


### PR DESCRIPTION
## Description
Linked to Issue: #8 
Add a pull request template to the repository so that the description field of a PR is pre-populated with the basic structure expected.

## Changes
* Add a `pull_request_template.md` containing three predetermined sections and a short description of what is expected in each section.

## Steps to QA
This will need to be verified post-merge as it will not take effect until it is committed to the repository's default branch. Check [the documentation](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository) to ensure that the correct steps were carried out to create this pull request template.