### PR TITLE
Update eslint script to specify file extensions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,13 @@
 module.exports = {
+  root: true,
   extends: ['airbnb'],
   plugins: ['jest'],
   env: {
     'jest/globals': true,
+    browser: true,
+    node: true,
+  },
+  rules: {
+    'prefer-arrow-callback': ['error', { allowNamedFunctions: true }],
   },
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,5 +9,12 @@ module.exports = {
   },
   rules: {
     'prefer-arrow-callback': ['error', { allowNamedFunctions: true }],
+    'no-console': ['error', { allow: ['warn', 'error'] }],
   },
+  overrides: [{
+    files: ['server/**/*.*'],
+    rules: {
+      'no-console': 'off',
+    },
+  }],
 };

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Exercises for JavaScript and Node",
   "main": "index.js",
   "scripts": {
-    "lint": "eslint .",
+    "lint": "eslint --ext .js,.jsx,.mjs,.ts,.tsx .",
     "start": "nodemon server/index.mjs",
     "test": "jest"
   },

--- a/server/index.mjs
+++ b/server/index.mjs
@@ -1,3 +1,5 @@
+/* eslint no-console: 0 */
+
 import express from 'express';
 
 const app = express();

--- a/server/index.mjs
+++ b/server/index.mjs
@@ -1,5 +1,3 @@
-/* eslint no-console: 0 */
-
 import express from 'express';
 
 const app = express();


### PR DESCRIPTION
## Description
Linked to Issue: #18 
Update npm script `lint` in `package.json` to specify file extensions: `.js`, `.jsx`, `.mjs`, `.ts`, and `.tsx`. As we work towards SSR, React, and TypeScript all of these filetypes will need linting.

This change also addresses a bug where the file `server/index.mjs` was not being linted by the script.

## Changes
* Update script `lint` in `package.json` to specify the target file extensions
* Update `.estlintrc.js`:
  * Set `root` to `true` to ensure eslint knows this is the root configuration for the project
  * Set `browser` and `node` envs to true to allow for globals in these environments
  * Configure rule `prefer-arrow-callback` to allow for named functions
  * Configure rule `no-console` to allow for warnings and errors
  * Configure override for files in the `server/` directory to be able to use the console
    * Console commands are necessary for the proper functioning of the server

## Steps to QA
* Pull down and switch to this branch
* Run `npm run lint` and ensure no failures
* Remove `rules` configurations, run `npm run lint` and see two failures for named function callbacks
* Remove `overrides` configurations, run `npm run lint` to see a warning about usage of `console`
