### PR TITLE
[.eslintrc] `wrap-iife` rule configured to enforce wrapping function expressions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -43,6 +43,11 @@ module.exports = {
         tsx: 'never',
       },
     ],
+    'wrap-iife': [
+      'error',
+      'inside',
+      { functionPrototypeMethods: true },
+    ],
   },
   settings: {
     'import/resolver': {


### PR DESCRIPTION
## Description
Linked to Issue: #17 
Linked to PR: #27 

Configure ESLint rule [wrap-iife](https://eslint.org/docs/latest/rules/wrap-iife) to enforce the wrapping of function expressions and calls to function expressions using function prototype methods (`.call()` and `.apply()`).

## Changes
* Add new rule to `.estlintrc.js` to enforce `wrap-iife` rule on wrapping function expressions, and calls using function prototype methods.

## Steps to QA
* Pull down and switch to this branch.
* Add a function expression to any file that wraps the function expression _and_ function call:

```javascript
(function foo() {
  console.warn('TEST');
}());
```
* Ensure eslint error `wrap-iife: Wrap only the function expression in parens.` is raised.
* Modify the function expression so that just the function expression is wrapped and not the call:

```javascript
(function foo() {
  console.warn('TEST');
})();
```
* Ensure no eslint error