### PR TITLE
Eslint: Filename conventions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,13 +1,22 @@
 module.exports = {
   root: true,
   extends: ['airbnb'],
-  plugins: ['jest'],
+  plugins: [
+    'jest',
+    'filenames',
+  ],
   env: {
     'jest/globals': true,
     browser: true,
     node: true,
   },
   overrides: [{
+    files: ['*.js', 'webpack-config/**/*.js'],
+    rules: {
+      'filenames/match-regex': 0,
+      'filenames/match-exported': 0,
+    },
+  }, {
     files: ['server/**/*.*'],
     rules: {
       'no-console': 'off',
@@ -19,20 +28,8 @@ module.exports = {
   }],
   ignorePatterns: ['dist/**/*.*'],
   rules: {
-    'react/jsx-filename-extension': [
-      2,
-      {
-        extensions: ['.js', '.jsx', '.ts', '.tsx'],
-      },
-    ],
-    'prefer-arrow-callback': [
-      'error',
-      { allowNamedFunctions: true },
-    ],
-    'no-console': [
-      'error',
-      { allow: ['warn', 'error'] },
-    ],
+    'filenames/match-regex': 2,
+    'filenames/match-exported': 2,
     'import/extensions': [
       'error',
       'ignorePackages',
@@ -41,6 +38,20 @@ module.exports = {
         ts: 'never',
         jsx: 'never',
         tsx: 'never',
+      },
+    ],
+    'no-console': [
+      'error',
+      { allow: ['warn', 'error'] },
+    ],
+    'prefer-arrow-callback': [
+      'error',
+      { allowNamedFunctions: true },
+    ],
+    'react/jsx-filename-extension': [
+      2,
+      {
+        extensions: ['.js', '.jsx', '.ts', '.tsx'],
       },
     ],
     'wrap-iife': [

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "eslint": "^8.57.0",
         "eslint-config-airbnb": "^19.0.4",
         "eslint-import-resolver-alias": "^1.1.2",
+        "eslint-plugin-filenames": "^1.3.2",
         "eslint-plugin-import": "^2.29.1",
         "eslint-plugin-jest": "^27.9.0",
         "jest": "^29.7.0",
@@ -5836,6 +5837,21 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
     },
+    "node_modules/eslint-plugin-filenames": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-filenames/-/eslint-plugin-filenames-1.3.2.tgz",
+      "integrity": "sha512-tqxJTiEM5a0JmRCUYQmxw23vtTxrb2+a3Q2mMOPhFxvt7ZQQJmdiuMby9B/vUAuVMghyP7oET+nIf6EO6CBd/w==",
+      "dev": true,
+      "dependencies": {
+        "lodash.camelcase": "4.3.0",
+        "lodash.kebabcase": "4.1.1",
+        "lodash.snakecase": "4.1.1",
+        "lodash.upperfirst": "4.3.1"
+      },
+      "peerDependencies": {
+        "eslint": "*"
+      }
+    },
     "node_modules/eslint-plugin-import": {
       "version": "2.29.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.29.1.tgz",
@@ -8507,16 +8523,40 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "dev": true
+    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
       "dev": true
     },
+    "node_modules/lodash.kebabcase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
+      "integrity": "sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g==",
+      "dev": true
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
+    },
+    "node_modules/lodash.snakecase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
+      "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==",
+      "dev": true
+    },
+    "node_modules/lodash.upperfirst": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz",
+      "integrity": "sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==",
       "dev": true
     },
     "node_modules/loose-envify": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "eslint": "^8.57.0",
     "eslint-config-airbnb": "^19.0.4",
     "eslint-import-resolver-alias": "^1.1.2",
+    "eslint-plugin-filenames": "^1.3.2",
     "eslint-plugin-import": "^2.29.1",
     "eslint-plugin-jest": "^27.9.0",
     "jest": "^29.7.0",


### PR DESCRIPTION
## Description
Linked to Issue: #19 
Enforce [filename conventions via ESlint](https://github.com/selaux/eslint-plugin-filenames):
* Filenames should be camel-cased
* Filenames should match the name of the default export

These rules do not apply to root directory configuration files or Webpack configuration files.

## Changes
* Add devDependency to `package.json`: `eslint-plugin-filenames`
* Configure `.eslintrc.js`:
  * Use plugin `filenames`
  * Enforce `filenames/match-regex` except on root and `webpack-config/` `.js` files
  * Enforce `filenames/match-exported` except on root and `webpack-config/` `.js` files

## Steps to QA
* Pull down and switch to this branch
* Run `npm run lint` and ensure passing linter
* Create a new file `app/Foo/foo_Bar.tsx`:

```javascript
import React from 'react';

export default function Foo() {
  return (<div>foobar</div>);
}
```

* Run `npm run lint` and ensure both filename rule violations:

![image](https://github.com/chichiwang/exercise-js/assets/2304118/00fc4f3d-f5fa-4a06-9393-1cca490ecd21)

