### PR TITLE
Add a page: `Counter` with a link to `/home`

### DIFF
--- a/app/Routes/__tests__/index.test.js
+++ b/app/Routes/__tests__/index.test.js
@@ -15,6 +15,16 @@ jest.mock('pages/Home', function mockHome() {
   };
 });
 
+jest.mock('pages/Counter', function mockHome() {
+  return function mockedHome() {
+    return (
+      <main>
+        <h1>Counter Route</h1>
+      </main>
+    );
+  };
+});
+
 describe('Routes', () => {
   test('renders the Home Component at the root route', () => {
     render(<Routes />, { wrapper: BrowserRouter });
@@ -33,6 +43,20 @@ describe('Routes', () => {
       );
 
       expect(screen.getByText(/Home Route/)).toBeInTheDocument();
+    });
+  });
+
+  describe('/counter', () => {
+    const path = '/counter';
+
+    test('renders the Home Component', () => {
+      render(
+        <MemoryRouter initialEntries={[path]}>
+          <Routes />
+        </MemoryRouter>,
+      );
+
+      expect(screen.getByText(/Counter Route/)).toBeInTheDocument();
     });
   });
 });

--- a/app/Routes/__tests__/index.test.js
+++ b/app/Routes/__tests__/index.test.js
@@ -15,8 +15,8 @@ jest.mock('pages/Home', function mockHome() {
   };
 });
 
-jest.mock('pages/Counter', function mockHome() {
-  return function mockedHome() {
+jest.mock('pages/Counter', function mockCounter() {
+  return function mockedCounter() {
     return (
       <main>
         <h1>Counter Route</h1>
@@ -49,7 +49,7 @@ describe('Routes', () => {
   describe('/counter', () => {
     const path = '/counter';
 
-    test('renders the Home Component', () => {
+    test('renders the Counter Component', () => {
       render(
         <MemoryRouter initialEntries={[path]}>
           <Routes />

--- a/app/Routes/index.tsx
+++ b/app/Routes/index.tsx
@@ -2,11 +2,13 @@ import React from 'react';
 import { Route, Routes as RouterRoutes } from 'react-router-dom';
 
 import Home from 'pages/Home';
+import Counter from 'pages/Counter';
 
 export default function Routes() {
   return (
     <RouterRoutes>
       <Route path="/" element={<Home />} />
+      <Route path="/counter" element={<Counter />} />
     </RouterRoutes>
   );
 }

--- a/pages/Counter/__tests__/__snapshots__/index.test.js.snap
+++ b/pages/Counter/__tests__/__snapshots__/index.test.js.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Counter Component matches snapshot 1`] = `
+<main>
+  <h1>
+    React Counter
+  </h1>
+  <a
+    href="/"
+    onClick={[Function]}
+  >
+    Back to home
+  </a>
+</main>
+`;

--- a/pages/Counter/__tests__/index.test.js
+++ b/pages/Counter/__tests__/index.test.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { MemoryRouter } from 'react-router-dom';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import Counter from '../index';
+
+function RouterWrappedCounter() {
+  return (
+    <MemoryRouter>
+      <Counter />
+    </MemoryRouter>
+  );
+}
+
+describe('Counter Component', () => {
+  test('matches snapshot', () => {
+    const tree = renderer.create(<RouterWrappedCounter />).toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('contains the counter text', () => {
+    render(<RouterWrappedCounter />);
+
+    expect(screen.getByRole('heading')).toHaveTextContent('React Counter');
+  });
+});

--- a/pages/Counter/index.tsx
+++ b/pages/Counter/index.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+export default function Counter(): React.ReactElement {
+  return (
+    <main>
+      <h1>React Counter</h1>
+      <Link to="/">Back to home</Link>
+    </main>
+  );
+}

--- a/pages/Home/__tests__/__snapshots__/Home.test.js.snap
+++ b/pages/Home/__tests__/__snapshots__/Home.test.js.snap
@@ -1,7 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`Home Component matches snapshot 1`] = `
-<h1>
-  Hello, React SSR!
-</h1>
-`;

--- a/pages/Home/__tests__/__snapshots__/index.test.js.snap
+++ b/pages/Home/__tests__/__snapshots__/index.test.js.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Home Component matches snapshot 1`] = `
+<main>
+  <h1>
+    Hello, React SSR!
+  </h1>
+  <a
+    href="/counter"
+    onClick={[Function]}
+  >
+    React Counter
+  </a>
+</main>
+`;

--- a/pages/Home/__tests__/index.test.js
+++ b/pages/Home/__tests__/index.test.js
@@ -1,19 +1,28 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
+import { MemoryRouter } from 'react-router-dom';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 import Home from '../index';
 
+function RouterWrappedHome() {
+  return (
+    <MemoryRouter>
+      <Home />
+    </MemoryRouter>
+  );
+}
+
 describe('Home Component', () => {
   test('matches snapshot', () => {
-    const tree = renderer.create(<Home />).toJSON();
+    const tree = renderer.create(<RouterWrappedHome />).toJSON();
 
     expect(tree).toMatchSnapshot();
   });
 
-  test('contains the hello texta', () => {
-    render(<Home />);
+  test('contains the hello text', () => {
+    render(<RouterWrappedHome />);
 
     expect(screen.getByRole('heading')).toHaveTextContent('Hello, React SSR!');
   });

--- a/pages/Home/index.tsx
+++ b/pages/Home/index.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 
 export default function Home(): React.ReactElement {
   return (
-    <h1>Hello, React SSR!</h1>
+    <main>
+      <h1>Hello, React SSR!</h1>
+      <Link to="/counter">React Counter</Link>
+    </main>
   );
 }


### PR DESCRIPTION
## Description
Linked to Issue: #19 
Add a second page `/counter` to the application to demonstrate that the routing implemented works both for client-side links and server-side rendering of non-root route requests. A link exists on the root page `/` to the new page `/counter` and vice versa. Both of these links work to trigger page-level rendering on the browser, as well as render the correct content from the server.

## Changes
* Create a page component `pages/Counter` with a simple heading and a link to `/`
* Add a link to `/counter` in `pages/Home`
* Add a route `/counter` in `app/Routes`

## Steps to QA
* Pull down and switch to this branch
* Run either `npm run build:run` or `npm start`
  * Navigate to the local server in browser, click on the link to `/counter` and ensure the page and url updates
    * Ensure through the server logs that a request was made for the page `/` but not for `/counter`
  * Click on the link to `/` and ensure the page and url updates
    * Ensure through the server logs that no request was made for the page `/`
  * Use the browser back button and ensure the page and url updates correctly
    * Ensure through server logs that no request was made for the page `/counter`
  * Perform a hard refresh or navigate in a new tab directly to `/counter` and ensure it renders correctly
    * Ensure through the server logs that a request was made for the page `/counter`
    * Check the developer tools network tab for the response to this to ensure the markup for the page was delivered correctly
