### PR TITLE
Create a `NotFound` page for 404 routing cases

### DIFF
--- a/app/Routes/__tests__/index.test.js
+++ b/app/Routes/__tests__/index.test.js
@@ -25,6 +25,16 @@ jest.mock('pages/Counter', function mockCounter() {
   };
 });
 
+jest.mock('pages/NotFound', function mockCounter() {
+  return function mockedCounter() {
+    return (
+      <main>
+        <h1>404 Route</h1>
+      </main>
+    );
+  };
+});
+
 describe('Routes', () => {
   test('renders the Home Component at the root route', () => {
     render(<Routes />, { wrapper: BrowserRouter });
@@ -57,6 +67,31 @@ describe('Routes', () => {
       );
 
       expect(screen.getByText(/Counter Route/)).toBeInTheDocument();
+    });
+  });
+
+  describe('404', () => {
+    const undefinedRoute1 = '/foobar';
+    const undefinedRoute2 = '/doesntexist';
+
+    test('renders the NotFound Component on an undefined path', () => {
+      render(
+        <MemoryRouter initialEntries={[undefinedRoute1]}>
+          <Routes />
+        </MemoryRouter>,
+      );
+
+      expect(screen.getByText(/404 Route/)).toBeInTheDocument();
+    });
+
+    test('renders the NotFound Component on another undefined path', () => {
+      render(
+        <MemoryRouter initialEntries={[undefinedRoute2]}>
+          <Routes />
+        </MemoryRouter>,
+      );
+
+      expect(screen.getByText(/404 Route/)).toBeInTheDocument();
     });
   });
 });

--- a/app/Routes/index.tsx
+++ b/app/Routes/index.tsx
@@ -3,12 +3,14 @@ import { Route, Routes as RouterRoutes } from 'react-router-dom';
 
 import Home from 'pages/Home';
 import Counter from 'pages/Counter';
+import NotFound from 'pages/NotFound';
 
 export default function Routes() {
   return (
     <RouterRoutes>
       <Route path="/" element={<Home />} />
       <Route path="/counter" element={<Counter />} />
+      <Route path="*" element={<NotFound />} />
     </RouterRoutes>
   );
 }

--- a/pages/NotFound/__tests__/__snapshots__/index.test.js.snap
+++ b/pages/NotFound/__tests__/__snapshots__/index.test.js.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NotFound Component matches snapshot 1`] = `
+<main>
+  <h1>
+    Page Not Found!
+  </h1>
+  <a
+    href="/"
+    onClick={[Function]}
+  >
+    Return to Home
+  </a>
+</main>
+`;

--- a/pages/NotFound/__tests__/index.test.js
+++ b/pages/NotFound/__tests__/index.test.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { MemoryRouter } from 'react-router-dom';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import NotFound from '../index';
+
+function RouterWrappedNotFound() {
+  return (
+    <MemoryRouter>
+      <NotFound />
+    </MemoryRouter>
+  );
+}
+
+describe('NotFound Component', () => {
+  test('matches snapshot', () => {
+    const tree = renderer.create(<RouterWrappedNotFound />).toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('contains the hello text', () => {
+    render(<RouterWrappedNotFound />);
+
+    expect(screen.getByRole('heading')).toHaveTextContent('Page Not Found!');
+  });
+});

--- a/pages/NotFound/index.tsx
+++ b/pages/NotFound/index.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+export default function NotFound(): React.ReactElement {
+  return (
+    <main>
+      <h1>Page Not Found!</h1>
+      <Link to="/">Return to Home</Link>
+    </main>
+  );
+}


### PR DESCRIPTION
## Description
Linked to Issue: #19 
Create a 404 page `pages/NotFound` that will render for any paths that do not exist in the application.

## Changes
* Create a page `pages/NotFound` to render in 404 cases
* Update `app/Routes` with a `*` catchall path to render `pages/NotFound`

## Steps to QA
* Pull down and switch to this branch
* Run `npm start` and navigate to the app in browser
  * Navigate to any number of non-existent routes in browser (ex: `/foober`, `/about`, `/info`) and ensure that the 404 page renders for all of them.
