### PR TITLE
Rename scripts: `build:run`, `start`

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,10 +5,11 @@
   "main": "index.js",
   "scripts": {
     "build:dev": "npm run clean && webpack --config webpack-config.js",
-    "build:run": "npm run build:dev && node dist/index.js | npx pino-pretty -c -S",
+    "build:devRun": "npm run build:dev && node dist/index.js | npx pino-pretty -c -S",
     "clean": "rm -rf dist",
     "lint": "eslint --ext .js,.jsx,.mjs,.ts,.tsx .",
-    "start": "webpack --config webpack-config.js --watch | npx pino-pretty -c -S",
+    "start": "echo 'TODO: build/build+run production assets'",
+    "watch": "webpack --config webpack-config.js --watch | npx pino-pretty -c -S",
     "test": "jest",
     "test:snapshot": "jest --updateSnapshot"
   },


### PR DESCRIPTION
## Description
Linked to Issue: #20
In planning for the execution of implementing CSS modules it is becoming more clear the need to separate configurations for development and production builds. In preparation for this, some npm scripts in `package.json` are being renamed to better reflect their planned usages in the future:
* `start`: Currently used for running the watch server, in the future should be used to start the production application.
* `build:run`: Currently build agnostic in name, but runs the development build in function. Renamed to indicate which build is being run.

## Changes
* Update scripts in `package.json`:
  * `start` - echoes a TODO item now, to indicate it should be used to either build and run the production build, or just run whatever build exists (for production)
  * `build:run` -> `build:devRun` - script name more indicative of which build is going to be run
  * `watch` - added to run the Webpack watch server

## Steps to QA
* Pull down and switch to this branch
* Run `npm run watch` to ensure watch server starts
* Run `npm run build:devRun` to ensure development builds correctly, and runs
