### PR TITLE
Add source mapping to development builds

### DIFF
--- a/webpack-config/base.js
+++ b/webpack-config/base.js
@@ -2,6 +2,7 @@ const paths = require('./paths');
 
 const baseConfig = {
   mode: 'development',
+  devtool: 'eval-source-map', // Use in dev only, different option/remove in prd
   module: {
     rules: [{
       test: /\.tsx?$/,


### PR DESCRIPTION
## Description
Linked to Issue: #20
Instrumenting CSS/SASS modules, we will want source mapping. [Source mapping](https://webpack.js.org/configuration/devtool/) is missing from the current Webpack development build, so this change adds it. The source mapping strategy chosen is intended for development builds only. The decision of which source mapping strategy (or even if there will be source mapping) to use in the production build will be deferred for now.

## Changes
* Add `devtool` option to `webpack-config/base.js`
  * `eval-source-map` was chosen for a combination of rebuild-speed and references to the original, pre-compiled code in development
  * A comment is added to ensure we address the source-map decision when we tackle the prd configuration options

## Steps to QA
* Pull down and switch to this branch
* Add a console log anywhere in the `app/` or `pages/` source files
* Run `npm run watch`, navigate to the site, click on the source for the console log in developer tools
  * Ensure the line reference links to the source in the original code