### PR TITLE
Fix: Webpack server restart config

### DIFF
--- a/webpack-config/server.js
+++ b/webpack-config/server.js
@@ -24,7 +24,9 @@ const serverConfig = {
   },
   plugins: [
     new NodemonPlugin({
-      watch: [paths.project.app, paths.project.client, paths.project.server],
+      watch: [
+        paths.outputs.root,
+      ],
       ignore: ['/__tests__/', '**.test.*'],
     }),
   ],


### PR DESCRIPTION
## Description
Linked to Issue: #38
There was a bug wherein on file change, the server was not restarting correctly (too quickly, perhaps), leading to a React mismatch in server rendered markup and React app hydration content. This was caused by [nodemon-webpack-plugin](https://www.npmjs.com/package/nodemon-webpack-plugin) watching the source files rather than the output files for changes before restarting the server.

## Changes
* `webpack-config/server.js` configuration fixed:
  * `NodemonPlugin` set to watch the output directory, rather than all the source directories

## Steps to QA
* On `main` branch run `npm run watch`
* Make a change to the rendered output of a React component in a source file such as `pages/Home/index.tsx` - ensure server restarts
* Navigate to the changed page in the browser and observe the browser console contains synchronization errors from a mismatch between server provided content and client hydration content
* Pull down and switch to this branch and run `npm run watch`
* Make the same change to the rendered output of a React component in a source file such as `pages/Home/index.tsx` - ensure server restarts
* Navigate to the changed page in the browser and observe the browser console contains no errors regarding content mismatch
