### PR TITLE
Create a split chunk: `vendors.js`

### DIFF
--- a/server/__tests__/appHandler.test.js
+++ b/server/__tests__/appHandler.test.js
@@ -109,7 +109,10 @@ describe('appHandler', () => {
     expect(renderToPipeableStream).toHaveBeenCalledWith(
       expect.any(Object),
       expect.objectContaining({
-        bootstrapScripts: expect.arrayContaining(['/scripts/app.js']),
+        bootstrapScripts: expect.arrayContaining([
+          '/scripts/vendors.js',
+          '/scripts/app.js',
+        ]),
         onShellReady: expect.any(Function),
         onError: expect.any(Function),
       }),

--- a/server/appHandler.tsx
+++ b/server/appHandler.tsx
@@ -51,7 +51,7 @@ export default async function appHandler(req: Request, res: Response) {
       <StaticRouterProvider router={router} context={context} />
     </App>,
     {
-      bootstrapScripts: ['/scripts/app.js'],
+      bootstrapScripts: ['/scripts/vendors.js', '/scripts/app.js'],
       onShellReady() {
         if (errored) {
           res.statusCode = 500;

--- a/webpack-config/client.js
+++ b/webpack-config/client.js
@@ -4,10 +4,23 @@ const baseConfig = require('./base');
 const clientConfig = {
   ...baseConfig,
   name: 'client',
-  entry: paths.entries.client,
+  entry: {
+    app: paths.entries.client,
+  },
   output: {
     path: paths.outputs.scripts,
-    filename: 'app.js',
+    filename: '[name].js',
+  },
+  optimization: {
+    splitChunks: {
+      cacheGroups: {
+        vendor: {
+          test: /node_modules/,
+          name: 'vendors',
+          chunks: 'all',
+        },
+      },
+    },
   },
 };
 


### PR DESCRIPTION
## Description
Linked to Issue: #31 
Create a separate chunk `vendors.js` distinct from `app.js` to house dependencies bundled from `node_modules/` directory

## Changes
* Update configuration `webpack-config/client.js`
  * [Split chunks optimization](https://webpack.js.org/plugins/split-chunks-plugin/) added to create a `vendors.js` chunk to house all vendor modules
* Update `server/appHandler.tsx` to load `/scripts/vendors.js` as a bootstrap script
  * Update tests

## Steps to QA
* On `main` branch run `npm run build:dev:analyze` and observe that the `app.js` bundle contains modules from `node_modules/` directory
* Pull down and switch to this branch
* Run `npm run build:dev:analyze` and observe that the `app.js` bundle no longer contains modules from `node_modules/` directory
* Observe the new `vendors.js` bundle only contains modules from the `node_modules/` directory
* Verify the server and app still behave correctly