### PR TITLE
Content hash webpack assets for production

### DIFF
--- a/app/App/__tests__/__snapshots__/index.test.js.snap
+++ b/app/App/__tests__/__snapshots__/index.test.js.snap
@@ -9,7 +9,7 @@ exports[`App Component matches child snapshot 1`] = `
       Hello, React SSR!
     </title>
     <link
-      href="/styles/app.css"
+      href="/Root CSS module"
       rel="stylesheet"
       type="text/css"
     />
@@ -31,7 +31,7 @@ exports[`App Component matches no-child snapshot 1`] = `
       Hello, React SSR!
     </title>
     <link
-      href="/styles/app.css"
+      href="/Root CSS module"
       rel="stylesheet"
       type="text/css"
     />

--- a/app/App/__tests__/index.test.js
+++ b/app/App/__tests__/index.test.js
@@ -9,16 +9,20 @@ function ChildComponent() {
   );
 }
 
+const mockedManifest = {
+  'app.css': 'Root CSS module',
+};
+
 describe('App Component', () => {
   test('matches no-child snapshot', () => {
-    const tree = renderer.create(<App />).toJSON();
+    const tree = renderer.create(<App manifest={mockedManifest} />).toJSON();
 
     expect(tree).toMatchSnapshot();
   });
 
   test('matches child snapshot', () => {
     const tree = renderer.create(
-      <App>
+      <App manifest={mockedManifest}>
         <ChildComponent />
       </App>,
     ).toJSON();

--- a/app/App/index.tsx
+++ b/app/App/index.tsx
@@ -1,15 +1,19 @@
 import React from 'react';
 import 'app/global.module.scss';
 
-type AppProps = React.PropsWithChildren;
+import { Manifest } from 'app/types';
 
-export default function App({ children }: AppProps): React.ReactElement {
+type AppProps = React.PropsWithChildren<{
+  manifest: Manifest;
+}>;
+
+export default function App({ manifest, children }: AppProps): React.ReactElement {
   return (
     <React.StrictMode>
       <html lang="en">
         <head>
           <title>Hello, React SSR!</title>
-          <link rel="stylesheet" type="text/css" href="/styles/app.css" />
+          <link rel="stylesheet" type="text/css" href={`/${manifest['app.css']}`} />
         </head>
         <body>
           { children }

--- a/app/types.ts
+++ b/app/types.ts
@@ -1,0 +1,11 @@
+type Manifest = {
+  'app.js': string;
+  'app.css': string;
+  'vendors.js': string;
+};
+
+export {
+  // Remove comment after adding more than one export
+  // eslint-disable-next-line
+  Manifest,
+};

--- a/client/entry.tsx
+++ b/client/entry.tsx
@@ -4,15 +4,24 @@ import {
   createBrowserRouter,
   RouterProvider,
 } from 'react-router-dom';
+import cookies from 'js-cookie';
 
+import { Manifest } from 'app/types';
 import App from 'app/App';
 import dataRoutes from 'app/dataRoutes';
 
 const router = createBrowserRouter(dataRoutes);
+const manifestCookie = cookies.get('manifest');
+
+if (!manifestCookie) {
+  throw new Error('[FATAL]: Manifest missing');
+}
+
+const manifest: Manifest = JSON.parse(manifestCookie);
 
 hydrateRoot(
   document,
-  <App>
+  <App manifest={manifest}>
     <RouterProvider router={router} />
   </App>,
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "express": "^4.19.2",
+        "js-cookie": "^3.0.5",
         "pino-http": "^9.0.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -23,6 +24,7 @@
         "@testing-library/jest-dom": "^6.4.2",
         "@testing-library/react": "^14.2.1",
         "@types/express": "^4.17.21",
+        "@types/js-cookie": "^3.0.6",
         "@types/node": "^20.11.24",
         "@types/react": "^18.2.65",
         "@types/react-dom": "^18.2.21",
@@ -3086,6 +3088,12 @@
       "dependencies": {
         "@types/istanbul-lib-report": "*"
       }
+    },
+    "node_modules/@types/js-cookie": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-3.0.6.tgz",
+      "integrity": "sha512-wkw9yd1kEXOPnvEeEV1Go1MmxtBJL0RR79aOTAApecWFVu7w0NNXNqhcWgvw2YgZDYadliXkl14pa3WXw5jlCQ==",
+      "dev": true
     },
     "node_modules/@types/jsdom": {
       "version": "20.0.1",
@@ -8671,6 +8679,14 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/js-tokens": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
         "webpack": "^5.90.3",
         "webpack-bundle-analyzer": "^4.10.1",
         "webpack-cli": "^5.1.4",
+        "webpack-manifest-plugin": "^5.0.0",
         "webpack-node-externals": "^3.0.0"
       }
     },
@@ -11066,6 +11067,12 @@
         "atomic-sleep": "^1.0.0"
       }
     },
+    "node_modules/source-list-map": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
+      "integrity": "sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==",
+      "dev": true
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -12280,6 +12287,35 @@
       "dev": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/webpack-manifest-plugin": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/webpack-manifest-plugin/-/webpack-manifest-plugin-5.0.0.tgz",
+      "integrity": "sha512-8RQfMAdc5Uw3QbCQ/CBV/AXqOR8mt03B6GJmRbhWopE8GzRfEpn+k0ZuWywxW+5QZsffhmFDY1J6ohqJo+eMuw==",
+      "dev": true,
+      "dependencies": {
+        "tapable": "^2.0.0",
+        "webpack-sources": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "peerDependencies": {
+        "webpack": "^5.47.0"
+      }
+    },
+    "node_modules/webpack-manifest-plugin/node_modules/webpack-sources": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-2.3.1.tgz",
+      "integrity": "sha512-y9EI9AO42JjEcrTJFOYmVywVZdKVUfOvDUPsJea5GIr1JOEGFVqwlY2K098fFoIjOkDzHn2AjRvM8dsBZu+gCA==",
+      "dev": true,
+      "dependencies": {
+        "source-list-map": "^2.0.1",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/webpack-merge": {

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "webpack": "^5.90.3",
     "webpack-bundle-analyzer": "^4.10.1",
     "webpack-cli": "^5.1.4",
+    "webpack-manifest-plugin": "^5.0.0",
     "webpack-node-externals": "^3.0.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@testing-library/jest-dom": "^6.4.2",
     "@testing-library/react": "^14.2.1",
     "@types/express": "^4.17.21",
+    "@types/js-cookie": "^3.0.6",
     "@types/node": "^20.11.24",
     "@types/react": "^18.2.65",
     "@types/react-dom": "^18.2.21",
@@ -76,6 +77,7 @@
   },
   "dependencies": {
     "express": "^4.19.2",
+    "js-cookie": "^3.0.5",
     "pino-http": "^9.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/server/__tests__/index.test.js
+++ b/server/__tests__/index.test.js
@@ -5,7 +5,7 @@ import appHandler from '../appHandler';
 
 jest.mock('express');
 jest.mock('pino-http');
-jest.mock('../appHandler');
+jest.mock('../appHandler', () => () => 'appHandler');
 
 const mockAppGet = jest.fn();
 const mockAppListen = jest.fn();

--- a/server/__tests__/manifest.test.js
+++ b/server/__tests__/manifest.test.js
@@ -1,0 +1,41 @@
+/* eslint-disable global-require */
+import { readFileSync } from 'node:fs';
+
+jest.mock('node:fs');
+
+const mockedManifest = {
+  'app.js': 'tenacious.d.js',
+};
+
+describe('manifest', () => {
+  let manifest;
+
+  beforeAll(() => {
+    readFileSync.mockReturnValue(JSON.stringify(mockedManifest));
+  });
+
+  beforeEach(() => {
+    jest.isolateModules(() => {
+      manifest = require('../manifest').default;
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    manifest = undefined;
+  });
+
+  test('reads manifest.json', () => {
+    expect(readFileSync).toHaveBeenCalledTimes(1);
+    expect(readFileSync).toHaveBeenCalledWith(
+      expect.stringMatching(/manifest.json$/),
+      expect.objectContaining({
+        encoding: 'utf-8',
+      }),
+    );
+  });
+
+  test('exports parsed JSON from the file', () => {
+    expect(manifest).toEqual(mockedManifest);
+  });
+});

--- a/server/appHandler.tsx
+++ b/server/appHandler.tsx
@@ -15,6 +15,7 @@ import App from 'app/App';
 import dataRoutes from 'app/dataRoutes';
 
 import createFetchRequest from './createFetchRequest';
+import manifest from './manifest';
 
 const handler = createStaticHandler(dataRoutes);
 
@@ -47,11 +48,11 @@ export default async function appHandler(req: Request, res: Response) {
   }, false);
 
   const { pipe } = renderToPipeableStream(
-    <App>
+    <App manifest={manifest}>
       <StaticRouterProvider router={router} context={context} />
     </App>,
     {
-      bootstrapScripts: ['/scripts/vendors.js', '/scripts/app.js'],
+      bootstrapScripts: [`/${manifest['vendors.js']}`, `/${manifest['app.js']}`],
       onShellReady() {
         if (errored) {
           res.statusCode = 500;
@@ -62,6 +63,7 @@ export default async function appHandler(req: Request, res: Response) {
         }
 
         res.setHeader('content-type', 'text/html');
+        res.cookie('manifest', JSON.stringify(manifest));
         pipe(res);
       },
       onError(err) {

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import express, {
   Express,

--- a/server/manifest.ts
+++ b/server/manifest.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { Manifest } from 'app/types';
+
+const manifestFilePath = path.resolve(__dirname, 'manifest.json');
+
+const manifestFileContents = readFileSync(manifestFilePath, {
+  encoding: 'utf-8',
+});
+
+const manifest: Manifest = JSON.parse(manifestFileContents);
+
+export default manifest;

--- a/webpack/client.js
+++ b/webpack/client.js
@@ -1,8 +1,10 @@
 /* eslint import/no-extraneous-dependencies: 0 */
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const { WebpackManifestPlugin } = require('webpack-manifest-plugin');
 
 const paths = require('./paths');
 const baseConfig = require('./base');
+const env = require('./env');
 const sassRules = require('./sassRules');
 
 const clientConfig = {
@@ -19,8 +21,9 @@ const clientConfig = {
     ],
   },
   output: {
-    path: paths.outputs.scripts,
-    filename: '[name].js',
+    path: paths.outputs.root,
+    filename: env.isDev ? 'scripts/[name].js' : 'scripts/[name].[contenthash].js',
+    chunkFilename: env.isDev ? 'scripts/[id].js' : 'scripts/[id].[contenthash].js',
   },
   optimization: {
     splitChunks: {
@@ -35,8 +38,11 @@ const clientConfig = {
   },
   plugins: [
     new MiniCssExtractPlugin({
-      filename: '../styles/[name].css',
-      chunkFilename: '../styles/[id].css',
+      filename: env.isDev ? 'styles/[name].css' : 'styles/[name].[contenthash].css',
+      chunkFilename: env.isDev ? 'styles/[id].css' : 'styles/[id].[contenthash].css',
+    }),
+    new WebpackManifestPlugin({
+      publicPath: '',
     }),
   ],
 };

--- a/webpack/paths.js
+++ b/webpack/paths.js
@@ -19,7 +19,6 @@ const paths = (function definePaths() {
 
   const outputs = {
     root: outputRoot,
-    scripts: path.resolve(outputRoot, 'scripts'),
   };
 
   return {


### PR DESCRIPTION
## Description
Linked to Issue: #45
[Content hashing](https://webpack.js.org/guides/caching/#output-filenames) implemented for production assets in Webpack, utilizing the strategy [explained in the issue thread](https://github.com/chichiwang/exercise-js/issues/45#issuecomment-2030325197).

Webpack is configured to build assets with content hashes in the filenames for production (not for non-production builds). Client and server are both updated to reference the manifest mapping when referring to these asset filenames.

## Changes
* `webpack/client.js` configuration updated
  * Include `contenthash` in the filenames of generated assets for production builds
  * Add plugin [webpack-manifest-plugin](https://www.npmjs.com/package/webpack-manifest-plugin) added to generate a `manifest.json` file in the output directory
* `webpack/paths.js` updated to remove a now unused `outputs.scripts` directory path
* `package.json` updated with new (dev)dependencies:
  * [js-cookie]: added as a dependency to parse cookies on the client
  * `@types/js-cookie`: devDependency added
  * `webpack-manifest-plugin`: devDependency added
* `server/manifest.ts` module added to read the manifest off the filesystem and parse it into a JS object for consumption
* `server/index.ts` updated to import `path` from `"node:path"` rather than from `"path"` in line with the [current API documentation](https://nodejs.org/api/path.html)
* `app/types.ts` file added for app-level type declarations: added a definition for `Manifest` type
* `app/App` updated to require a `manifest` property
  * Use the manifest to determine the proper pathing of `app.css`
* `client/entry.tsx` updated to read the manifest from the manifest cookie
  * Feeds the manifest into the rendering of `<App />`
  * Throws a fatal exception if the manifest cookie is not found
* `server/appHandler.tsx` updated to read the manifest from the manifest module `server/manifest.ts`
  * Sets a cookie `manifest` to the response object when handling an app request
  * Feeds the manifest into the rendering of `<App />`

## Steps to QA
* Pull down and switch to this branch
* For the following operations: `npm watch`, `npm run build:dev:run`, `npm run build:prod:run`:
  * Verify webpack builds correctly and the server runs without issue
  * Verify in browser the app runs fine with no console errors related to the scripts/css loading
  * Verify in browser the correct `.js` and `.css` assets load

![image](https://github.com/chichiwang/exercise-js/assets/2304118/bbfee2f5-9260-44f2-985f-fbe8a4962db1)

  * Verify in browser that manifest cookie is set

![image](https://github.com/chichiwang/exercise-js/assets/2304118/80d2737b-2c55-40a6-830f-66bd4056386f)