### PR TITLE
Fix: NPM script `clean` will not fail when `stats.json` doesn't exist

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build:dev": "webpack --config webpack/config.js --profile --json > stats.json",
     "prebuild:prod": "npm run clean",
     "build:prod": "NODE_ENV=prod webpack --config webpack/config.js --profile --json > stats.json",
-    "clean": "rm stats.json && rm -rf dist",
+    "clean": "rm -f stats.json && rm -rf dist",
     "dev": "run-s build:dev run | pino-pretty -c -S",
     "lint": "eslint --ext .js,.jsx,.mjs,.ts,.tsx .",
     "prod": "run-s build:prod run | pino-pretty -c -S",


### PR DESCRIPTION
## Description
Linked to Issue: #61 
A bug exists wherein running `npm run clean` will fail if `stats.json` doesn't exist (fresh repository, `clean` run twice in a row). This causes any other NPM script that relies on `clean` to fail as well. This PR fixes the script by adding the force flag (`-f`) to the `rm` command so that it ignores non-existent files without exiting with an error code.

## Changes
* Update `clean` script in `package.json`
  * Add a force flag `-f` to the `rm` command for `stats.json` so that if it doesn't exist it is ignored and does not error out

## Steps to QA
* Pull down this branch and switch to it
* Run `npm run clean`
  * Ensure that neither `stats.json` nor `dist/` exists in the project
* Run `npm run build:dev`
  * Ensure that `stats.json` and `dist/` are generated, and the process does not error out
