### PR TITLE
Implement a server logger

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "express": "^4.19.2",
         "js-cookie": "^3.0.5",
+        "pino": "^8.20.0",
         "pino-http": "^9.0.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -10195,14 +10196,14 @@
       }
     },
     "node_modules/pino": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-8.19.0.tgz",
-      "integrity": "sha512-oswmokxkav9bADfJ2ifrvfHUwad6MLp73Uat0IkQWY3iAw5xTRoznXbXksZs8oaOUMpmhVWD+PZogNzllWpJaA==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-8.20.0.tgz",
+      "integrity": "sha512-uhIfMj5TVp+WynVASaVEJFTncTUe4dHBq6CWplu/vBgvGHhvBvQfxz+vcOrnnBQdORH3izaGEurLfNlq3YxdFQ==",
       "dependencies": {
         "atomic-sleep": "^1.0.0",
         "fast-redact": "^3.1.1",
         "on-exit-leak-free": "^2.1.0",
-        "pino-abstract-transport": "v1.1.0",
+        "pino-abstract-transport": "^1.1.0",
         "pino-std-serializers": "^6.0.0",
         "process-warning": "^3.0.0",
         "quick-format-unescaped": "^4.0.3",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
   "dependencies": {
     "express": "^4.19.2",
     "js-cookie": "^3.0.5",
+    "pino": "^8.20.0",
     "pino-http": "^9.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/server/__tests__/appHandler.test.js
+++ b/server/__tests__/appHandler.test.js
@@ -10,6 +10,7 @@ import { renderToPipeableStream } from 'react-dom/server';
 import App from 'app/App';
 import dataRoutes from 'app/dataRoutes';
 import createFetchRequest from '../createFetchRequest';
+import logger from '../logger';
 
 const mockedManifest = {
   'app.js': 'path/to/app.supercomplexhash.js',
@@ -19,6 +20,7 @@ const mockedManifest = {
 jest.mock('react-router-dom/server');
 jest.mock('react-dom/server');
 jest.mock('../createFetchRequest');
+jest.mock('../logger');
 jest.mock('../manifest', () => mockedManifest);
 
 const mockedRes = {
@@ -52,7 +54,6 @@ const mockedStaticRouter = 'Buzz Buzz';
 const mockedFetchRequest = 'Severus, please fetch me the strongest truth potion you posess';
 
 const mockPipe = jest.fn();
-let mockConsoleErr;
 let appHandler;
 
 describe('appHandler', () => {
@@ -64,8 +65,6 @@ describe('appHandler', () => {
   });
 
   beforeEach(() => {
-    mockConsoleErr = jest.spyOn(console, 'error').mockImplementation(() => {});
-
     delete mockedRes.statusCode;
 
     jest.isolateModules(() => {
@@ -75,7 +74,6 @@ describe('appHandler', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
-    mockConsoleErr.mockRestore();
   });
 
   test('creates a static handler', () => {
@@ -96,7 +94,7 @@ describe('appHandler', () => {
 
     resSocketOnCallback(mockErr);
 
-    expect(mockConsoleErr).toHaveBeenCalledWith('Fatal:', mockErr);
+    expect(logger.error).toHaveBeenCalledWith('Fatal:', mockErr);
   });
 
   test('creates a static router', async () => {
@@ -182,8 +180,8 @@ describe('appHandler', () => {
       streamConfig.onError(streamErr);
       streamConfig.onShellReady();
 
-      expect(mockConsoleErr).toHaveBeenCalledTimes(1);
-      expect(mockConsoleErr).toHaveBeenCalledWith('Streaming failure:', streamErr);
+      expect(logger.error).toHaveBeenCalledTimes(1);
+      expect(logger.error).toHaveBeenCalledWith('Streaming failure:', streamErr);
       expect(mockedRes.statusCode).toBe(500);
     });
 

--- a/server/__tests__/httpLogger.test.js
+++ b/server/__tests__/httpLogger.test.js
@@ -1,0 +1,19 @@
+/* eslint-disable global-require */
+import pinoHttp from 'pino-http';
+
+jest.mock('pino-http');
+
+const mockLogger = jest.fn();
+
+let httpLogger;
+
+describe('httpLogger', () => {
+  beforeAll(() => {
+    pinoHttp.mockReturnValue(mockLogger);
+    httpLogger = require('../httpLogger').default;
+  });
+
+  test('returns an instance of a pino httpLogger', () => {
+    expect(httpLogger).toEqual(mockLogger);
+  });
+});

--- a/server/__tests__/httpLogger.test.js
+++ b/server/__tests__/httpLogger.test.js
@@ -14,6 +14,6 @@ describe('httpLogger', () => {
   });
 
   test('returns an instance of a pino httpLogger', () => {
-    expect(httpLogger).toEqual(mockLogger);
+    expect(httpLogger).toBe(mockLogger);
   });
 });

--- a/server/__tests__/logger.test.js
+++ b/server/__tests__/logger.test.js
@@ -14,6 +14,6 @@ describe('logger', () => {
   });
 
   test('returns an instance of a pino logger', () => {
-    expect(logger).toEqual(mockLogger);
+    expect(logger).toBe(mockLogger);
   });
 });

--- a/server/__tests__/logger.test.js
+++ b/server/__tests__/logger.test.js
@@ -1,0 +1,19 @@
+/* eslint-disable global-require */
+import pino from 'pino';
+
+jest.mock('pino');
+
+const mockLogger = jest.fn();
+
+let logger;
+
+describe('logger', () => {
+  beforeAll(() => {
+    pino.mockReturnValue(mockLogger);
+    logger = require('../logger').default;
+  });
+
+  test('returns an instance of a pino logger', () => {
+    expect(logger).toEqual(mockLogger);
+  });
+});

--- a/server/appHandler.tsx
+++ b/server/appHandler.tsx
@@ -14,6 +14,7 @@ import {
 import App from 'app/App';
 import dataRoutes from 'app/dataRoutes';
 
+import logger from './logger';
 import createFetchRequest from './createFetchRequest';
 import manifest from './manifest';
 
@@ -24,7 +25,7 @@ export default async function appHandler(req: Request, res: Response) {
   const notFoundPath = '*';
 
   res.socket?.on('error', function responseErr(err) {
-    console.error('Fatal:', err);
+    logger.error('Fatal:', err);
   });
 
   const fetchRequest = createFetchRequest(req, res);
@@ -68,7 +69,7 @@ export default async function appHandler(req: Request, res: Response) {
       },
       onError(err) {
         errored = true;
-        console.error('Streaming failure:', err);
+        logger.error('Streaming failure:', err);
       },
     },
   );

--- a/server/httpLogger.ts
+++ b/server/httpLogger.ts
@@ -1,0 +1,5 @@
+import pinoHttp from 'pino-http';
+
+export const httpLogger = pinoHttp();
+
+export default httpLogger;

--- a/server/index.ts
+++ b/server/index.ts
@@ -3,20 +3,20 @@ import path from 'node:path';
 import express, {
   Express,
 } from 'express';
-import pino from 'pino-http';
 
+import logger from './logger';
+import httpLogger from './httpLogger';
 import appHandler from './appHandler';
 
 const app: Express = express();
-const logger = pino();
 const port: Number = 8080;
 
-app.use(logger);
+app.use(httpLogger);
 app.use('/scripts', express.static(path.resolve(__dirname, 'scripts')));
 app.use('/styles', express.static(path.resolve(__dirname, 'styles')));
 
 app.get('*', appHandler);
 
 app.listen(port, function serverListening() {
-  console.log(`[server] Server is listening at http://127.0.0.1:${port}`);
+  logger.info(`[server] Server is listening at http://127.0.0.1:${port}`);
 });

--- a/server/logger.ts
+++ b/server/logger.ts
@@ -1,0 +1,5 @@
+import pino from 'pino';
+
+const logger = pino();
+
+export default logger;


### PR DESCRIPTION
## Description
Linked to Issue: #57 
Instrument [pino](https://getpino.io/) as a Node.js logger on the server to use instead of `console` statements. In the future this can provide flexibility in [configuration](https://getpino.io/#/docs/api?id=options) and further utility.

[pino-http](https://getpino.io/#/docs/web?id=pino-with-express) is already being used as HTTP middleware for logging HTTP events (request/response chain).

The logger and HTTP logger middleware are both moved to their own modules to serve up a single instance of each.

## Changes
* Add dependency to `package.json`: `pino`
* Add module `server/logger.ts` to serve a single instance of a pino logger
* Add module `server/httpLogger.ts` to serve a single instance of a pino http logger
* Update `server/index.ts`
  * Replace `console.log` statement with `logger.info` statement
  * Import logger and http logger from their respective modules
* Update `server/appHandler.tsx`
  * Replace `console.error` statements with `logger.error` statements

## Steps to QA
* Pull down and switch to this branch
* Run `npm watch` or `npm dev` and ensure on server start the info statement that the server started up still appears correctly
