### PR TITLE
Instrument basic application error handling

### DIFF
--- a/app/App/index.tsx
+++ b/app/App/index.tsx
@@ -3,6 +3,9 @@ import 'app/global.module.scss';
 
 import { Manifest } from 'app/types';
 
+import ErrorBoundary from 'app/ErrorBoundary';
+import ErrorPage from 'pages/ErrorPage';
+
 type AppProps = React.PropsWithChildren<{
   manifest: Manifest;
 }>;
@@ -16,7 +19,9 @@ export default function App({ manifest, children }: AppProps): React.ReactElemen
           <link rel="stylesheet" type="text/css" href={`/${manifest['app.css']}`} />
         </head>
         <body>
-          { children }
+          <ErrorBoundary fallback={<ErrorPage />}>
+            { children }
+          </ErrorBoundary>
         </body>
       </html>
     </React.StrictMode>

--- a/app/App/index.tsx
+++ b/app/App/index.tsx
@@ -3,9 +3,6 @@ import 'app/global.module.scss';
 
 import { Manifest } from 'app/types';
 
-import ErrorBoundary from 'app/ErrorBoundary';
-import ErrorPage from 'pages/ErrorPage';
-
 type AppProps = React.PropsWithChildren<{
   manifest: Manifest;
 }>;
@@ -19,9 +16,7 @@ export default function App({ manifest, children }: AppProps): React.ReactElemen
           <link rel="stylesheet" type="text/css" href={`/${manifest['app.css']}`} />
         </head>
         <body>
-          <ErrorBoundary fallback={<ErrorPage />}>
-            { children }
-          </ErrorBoundary>
+          { children }
         </body>
       </html>
     </React.StrictMode>

--- a/app/ErrorBoundary/__tests__/index.test.js
+++ b/app/ErrorBoundary/__tests__/index.test.js
@@ -1,0 +1,74 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import ErrorBoundary from '../index';
+
+function FallbackComponent() {
+  return (
+    <h1>Fallback Rendered!</h1>
+  );
+}
+
+function ComponentWithoutError() {
+  return (
+    <h1>Error Free Component</h1>
+  );
+}
+
+const mockErr = new Error('The bed is full of poop');
+
+function ComponentWithError() {
+  if (Math.random() >= 0) {
+    throw mockErr;
+  }
+
+  return (
+    <h1>You never saw this</h1>
+  );
+}
+
+let consoleErrorSpy;
+let consoleWarnSpy;
+
+describe('ErrorBoundary Component', () => {
+  beforeAll(() => {
+    consoleErrorSpy = jest.spyOn(console, 'error');
+    consoleWarnSpy = jest.spyOn(console, 'warn');
+
+    consoleErrorSpy.mockImplementation(() => {});
+    consoleWarnSpy.mockImplementation(() => {});
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('renders children if no errors are thrown', () => {
+    render(
+      <ErrorBoundary fallback={<FallbackComponent />}>
+        <ComponentWithoutError />
+      </ErrorBoundary>,
+    );
+
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(0);
+    expect(consoleWarnSpy).toHaveBeenCalledTimes(0);
+    expect(screen.getByRole('heading')).toHaveTextContent('Error Free Component');
+  });
+
+  test('renders fallback component if errors are thrown', () => {
+    render(
+      <ErrorBoundary fallback={<FallbackComponent />}>
+        <ComponentWithError />
+      </ErrorBoundary>,
+    );
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(mockErr);
+    expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole('heading')).toHaveTextContent('Fallback Rendered!');
+  });
+});

--- a/app/ErrorBoundary/index.tsx
+++ b/app/ErrorBoundary/index.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+
+type ErrorBoundaryProps = {
+  fallback: React.ReactNode;
+  children: React.ReactNode;
+};
+
+type ErrorBoundaryState = {
+  errored: Boolean;
+};
+
+class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+
+    this.state = {
+      errored: false,
+    };
+  }
+
+  static getDerivedStateFromError() {
+    return { errored: true };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    console.warn(info.componentStack);
+    console.error(error);
+  }
+
+  render() {
+    const { props, state } = this;
+
+    if (state.errored) {
+      return props.fallback;
+    }
+
+    return props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/app/dataRoutes/__tests__/index.test.js
+++ b/app/dataRoutes/__tests__/index.test.js
@@ -58,6 +58,7 @@ describe('dataRoutes', () => {
     for (const route of dataRoutes) {
       expect(route).toEqual(expect.objectContaining({
         path: expect.any(String),
+        Component: expect.any(Function),
       }));
     }
   });
@@ -68,6 +69,13 @@ describe('dataRoutes', () => {
 
     test('is defined', () => {
       expect(homeRoute).not.toBe(undefined);
+    });
+
+    test('defines an error boundary', () => {
+      expect(homeRoute).toEqual(expect.objectContaining({
+        path,
+        errorElement: <MockedErrorPage />,
+      }));
     });
 
     test('assigns the Home component', () => {
@@ -86,6 +94,13 @@ describe('dataRoutes', () => {
       expect(counterRoute).not.toBe(undefined);
     });
 
+    test('defines an error boundary', () => {
+      expect(counterRoute).toEqual(expect.objectContaining({
+        path,
+        errorElement: <MockedErrorPage />,
+      }));
+    });
+
     test('assigns the Counter component', () => {
       expect(counterRoute).toEqual(expect.objectContaining({
         path,
@@ -100,6 +115,10 @@ describe('dataRoutes', () => {
 
     test('is defined', () => {
       expect(errorRoute).not.toBe(undefined);
+    });
+
+    test('does not define an error boundary', () => {
+      expect(Object.prototype.hasOwnProperty.call(errorRoute, 'errorElement')).toBe(false);
     });
 
     test('assigns the Counter component', () => {
@@ -120,6 +139,13 @@ describe('dataRoutes', () => {
 
     test('is the last route defined', () => {
       expect(dataRoutes[dataRoutes.length - 1]).toBe(notFoundRoute);
+    });
+
+    test('defines an error boundary', () => {
+      expect(notFoundRoute).toEqual(expect.objectContaining({
+        path,
+        errorElement: <MockedErrorPage />,
+      }));
     });
 
     test('assigns the NotFound component', () => {

--- a/app/dataRoutes/__tests__/index.test.js
+++ b/app/dataRoutes/__tests__/index.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 
 import Home from 'pages/Home';
 import Counter from 'pages/Counter';
+import ErrorPage from 'pages/ErrorPage';
 import NotFound from 'pages/NotFound';
 
 import dataRoutes from '../index';
@@ -24,11 +25,20 @@ function MockedNotFound() {
   );
 }
 
+function MockedErrorPage() {
+  return (
+    <h1>Error Page</h1>
+  );
+}
+
 jest.mock('pages/Home', function MockHome() {
   return MockedHome;
 });
 jest.mock('pages/Counter', function MockCounter() {
   return MockedCounter;
+});
+jest.mock('pages/ErrorPage', function MockCounter() {
+  return MockedErrorPage;
 });
 jest.mock('pages/NotFound', function MockNotFound() {
   return MockedNotFound;
@@ -43,6 +53,7 @@ function findRouteByPath(routes, path) {
 describe('dataRoutes', () => {
   test('is an array of route objects', () => {
     expect(dataRoutes).toEqual(expect.any(Array));
+    expect(dataRoutes.length).toBe(4);
 
     for (const route of dataRoutes) {
       expect(route).toEqual(expect.objectContaining({
@@ -54,6 +65,10 @@ describe('dataRoutes', () => {
   describe('home route "/"', () => {
     const path = '/';
     const homeRoute = findRouteByPath(dataRoutes, path);
+
+    test('is defined', () => {
+      expect(homeRoute).not.toBe(undefined);
+    });
 
     test('assigns the Home component', () => {
       expect(homeRoute).toEqual(expect.objectContaining({
@@ -67,6 +82,10 @@ describe('dataRoutes', () => {
     const path = '/counter';
     const counterRoute = findRouteByPath(dataRoutes, path);
 
+    test('is defined', () => {
+      expect(counterRoute).not.toBe(undefined);
+    });
+
     test('assigns the Counter component', () => {
       expect(counterRoute).toEqual(expect.objectContaining({
         path,
@@ -75,9 +94,33 @@ describe('dataRoutes', () => {
     });
   });
 
+  describe('error page route "/error"', () => {
+    const path = '/error';
+    const errorRoute = findRouteByPath(dataRoutes, path);
+
+    test('is defined', () => {
+      expect(errorRoute).not.toBe(undefined);
+    });
+
+    test('assigns the Counter component', () => {
+      expect(errorRoute).toEqual(expect.objectContaining({
+        path,
+        Component: ErrorPage,
+      }));
+    });
+  });
+
   describe('not-found route "*"', () => {
     const path = '*';
     const notFoundRoute = findRouteByPath(dataRoutes, path);
+
+    test('is defined', () => {
+      expect(notFoundRoute).not.toBe(undefined);
+    });
+
+    test('is the last route defined', () => {
+      expect(dataRoutes[dataRoutes.length - 1]).toBe(notFoundRoute);
+    });
 
     test('assigns the NotFound component', () => {
       expect(notFoundRoute).toEqual(expect.objectContaining({

--- a/app/dataRoutes/__tests__/withErrorBoundary.test.js
+++ b/app/dataRoutes/__tests__/withErrorBoundary.test.js
@@ -1,0 +1,21 @@
+import React from 'react';
+
+import withErrorBoundary from '../withErrorBoundary';
+
+function MockErrorPage() {
+  return (
+    <h1>Oops!</h1>
+  );
+}
+
+jest.mock('pages/ErrorPage', () => MockErrorPage);
+
+describe('withErrorBoundary', () => {
+  test('applies errorElement to route object', () => {
+    const routeObj = {};
+
+    expect(withErrorBoundary(routeObj)).toEqual(expect.objectContaining({
+      errorElement: <MockErrorPage />,
+    }));
+  });
+});

--- a/app/dataRoutes/index.ts
+++ b/app/dataRoutes/index.ts
@@ -2,6 +2,7 @@ import { RouteObject } from 'react-router-dom';
 
 import Home from 'pages/Home';
 import Counter from 'pages/Counter';
+import ErrorPage from 'pages/ErrorPage';
 import NotFound from 'pages/NotFound';
 
 const dataRoutes: RouteObject[] = [{
@@ -10,6 +11,9 @@ const dataRoutes: RouteObject[] = [{
 }, {
   path: '/counter',
   Component: Counter,
+}, {
+  path: '/error',
+  Component: ErrorPage,
 }, {
   path: '*',
   Component: NotFound,

--- a/app/dataRoutes/index.ts
+++ b/app/dataRoutes/index.ts
@@ -5,18 +5,25 @@ import Counter from 'pages/Counter';
 import ErrorPage from 'pages/ErrorPage';
 import NotFound from 'pages/NotFound';
 
-const dataRoutes: RouteObject[] = [{
-  path: '/',
-  Component: Home,
-}, {
-  path: '/counter',
-  Component: Counter,
-}, {
-  path: '/error',
-  Component: ErrorPage,
-}, {
-  path: '*',
-  Component: NotFound,
-}];
+import withErrorBoundary from './withErrorBoundary';
+
+const dataRoutes: RouteObject[] = [
+  withErrorBoundary({
+    path: '/',
+    Component: Home,
+  }),
+  withErrorBoundary({
+    path: '/counter',
+    Component: Counter,
+  }),
+  {
+    path: '/error',
+    Component: ErrorPage,
+  },
+  withErrorBoundary({
+    path: '*',
+    Component: NotFound,
+  }),
+];
 
 export default dataRoutes;

--- a/app/dataRoutes/withErrorBoundary.tsx
+++ b/app/dataRoutes/withErrorBoundary.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { RouteObject } from 'react-router-dom';
+
+import ErrorPage from 'pages/ErrorPage';
+
+function withErrorBoundary(route: RouteObject): RouteObject {
+  return {
+    ...route,
+    errorElement: <ErrorPage />,
+  };
+}
+
+export default withErrorBoundary;

--- a/pages/ErrorPage/__tests__/__snapshots__/index.test.js.snap
+++ b/pages/ErrorPage/__tests__/__snapshots__/index.test.js.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ErrorPage Component matches snapshot 1`] = `
+<main>
+  <h1>
+    An Error Occurred!
+  </h1>
+  <a
+    href="/"
+    onClick={[Function]}
+  >
+    Home
+  </a>
+</main>
+`;

--- a/pages/ErrorPage/__tests__/index.test.js
+++ b/pages/ErrorPage/__tests__/index.test.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { MemoryRouter } from 'react-router-dom';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import ErrorPage from '../index';
+
+function RouterWrappedErrorPage() {
+  return (
+    <MemoryRouter>
+      <ErrorPage />
+    </MemoryRouter>
+  );
+}
+
+describe('ErrorPage Component', () => {
+  test('matches snapshot', () => {
+    const tree = renderer.create(<RouterWrappedErrorPage />).toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('contains the error text', () => {
+    render(<RouterWrappedErrorPage />);
+
+    expect(screen.getByRole('heading')).toHaveTextContent('An Error Occurred!');
+  });
+});

--- a/pages/ErrorPage/index.tsx
+++ b/pages/ErrorPage/index.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+export default function ErrorPage() {
+  return (
+    <main>
+      <h1>An Error Occurred!</h1>
+      <Link to="/">Home</Link>
+    </main>
+  );
+}

--- a/server/__tests__/appHandler.test.js
+++ b/server/__tests__/appHandler.test.js
@@ -25,6 +25,7 @@ jest.mock('../manifest', () => mockedManifest);
 
 const mockedRes = {
   cookie: jest.fn(),
+  redirect: jest.fn(),
   send: jest.fn(),
   socket: {
     on: jest.fn(),
@@ -183,6 +184,17 @@ describe('appHandler', () => {
       expect(logger.error).toHaveBeenCalledTimes(1);
       expect(logger.error).toHaveBeenCalledWith('Streaming failure:', streamErr);
       expect(mockedRes.statusCode).toBe(500);
+    });
+
+    test('redirects to /error on stream failure', async () => {
+      await appHandler(mockedReq, mockedRes);
+
+      const streamErr = 'Something catastrophic';
+      const streamConfig = renderToPipeableStream.mock.calls[0][1];
+      streamConfig.onError(streamErr);
+      streamConfig.onShellReady();
+
+      expect(mockedRes.redirect).toHaveBeenCalledWith('/error');
     });
 
     test('sets statusCode to 404 on when path match not found', async () => {

--- a/server/appHandler.tsx
+++ b/server/appHandler.tsx
@@ -25,7 +25,7 @@ export default async function appHandler(req: Request, res: Response) {
   const notFoundPath = '*';
 
   res.socket?.on('error', function responseErr(err) {
-    logger.error('Fatal:', err);
+    logger.error(err);
   });
 
   const fetchRequest = createFetchRequest(req, res);
@@ -50,7 +50,7 @@ export default async function appHandler(req: Request, res: Response) {
 
   if (contextIsResponse) {
     // Cannot create a static router if handler.query returned a Response object
-    logger.error('[Error]: handler query returned a Response object');
+    logger.error(new Error('Handler query returned a Response object'));
     res.status(500).redirect('/error');
     return;
   }
@@ -80,9 +80,13 @@ export default async function appHandler(req: Request, res: Response) {
         res.cookie('manifest', JSON.stringify(manifest));
         pipe(res);
       },
+      onShellError(err) {
+        logger.error(err);
+        res.status(500).redirect('/error');
+      },
       onError(err) {
         errored = true;
-        logger.error('Streaming failure:', err);
+        logger.error(err);
       },
     },
   );

--- a/server/appHandler.tsx
+++ b/server/appHandler.tsx
@@ -8,7 +8,6 @@ import {
   createStaticHandler,
   createStaticRouter,
   StaticRouterProvider,
-  StaticHandlerContext,
 } from 'react-router-dom/server';
 
 import App from 'app/App';
@@ -19,6 +18,7 @@ import createFetchRequest from './createFetchRequest';
 import manifest from './manifest';
 
 const handler = createStaticHandler(dataRoutes);
+const redirectCodes = [301, 302, 303, 307, 308];
 
 export default async function appHandler(req: Request, res: Response) {
   let errored = false;
@@ -37,16 +37,29 @@ export default async function appHandler(req: Request, res: Response) {
    *     - Log errors
    *     - Redirect to 500 page
    */
-  const context = await handler.query(fetchRequest) as StaticHandlerContext;
+  const context = await handler.query(fetchRequest);
+
+  const contextIsResponse = 'status' in context;
+  const isRedirect = contextIsResponse && redirectCodes.includes(context.status);
+  const redirectLocation = isRedirect && context.headers.get('location');
+
+  if (isRedirect && redirectLocation) {
+    res.status(context.status).redirect(redirectLocation);
+    return;
+  }
+
+  if (contextIsResponse) {
+    // Cannot create a static router if handler.query returned a Response object
+    logger.error('[Error]: handler query returned a Response object');
+    res.status(500).redirect('/error');
+    return;
+  }
+
   const router = createStaticRouter(handler.dataRoutes, context);
 
-  const notFound = context.matches.reduce(function notFoundReducer(isFound, match) {
-    if (match.route.path === notFoundPath) {
-      return true;
-    }
-
-    return false || isFound;
-  }, false);
+  const notFound = Boolean(context.matches.find(function find404(match) {
+    return match.route.path === notFoundPath;
+  }));
 
   const { pipe } = renderToPipeableStream(
     <App manifest={manifest}>
@@ -57,7 +70,6 @@ export default async function appHandler(req: Request, res: Response) {
       onShellReady() {
         if (errored) {
           res.statusCode = 500;
-          res.redirect('/error');
         } else if (notFound) {
           res.statusCode = 404;
         } else {

--- a/server/appHandler.tsx
+++ b/server/appHandler.tsx
@@ -57,6 +57,7 @@ export default async function appHandler(req: Request, res: Response) {
       onShellReady() {
         if (errored) {
           res.statusCode = 500;
+          res.redirect('/error');
         } else if (notFound) {
           res.statusCode = 404;
         } else {


### PR DESCRIPTION
## Description
Linked to Issue: #58 
Create an Error Page and an [Error Boundary](https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary) for the application. The Error Boundary is set up to wrap around all contents of the application `<body>` tag.

Additionally, 500 errors from the server in the streaming of the rendered application will redirect to the new Error Page with a [500 http status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500). [Redirects coming from React Router](https://reactrouter.com/en/main/guides/ssr#redirects) on server render will cause the server to respond with a redirect.

## Changes
* Create a page `pages/ErrorPage/index.tsx`
* Create error boundary `app/ErrorBoundary/index.tsx`
* Update `app/dataRoutes/index.ts` to route `/error` to `pages/ErrorPage`
* Create utility `app/dataRoutes/withErrorBoundary.tsx`
  * Wrap app routes except for `/error` in `app/dataRoutes/index.tsx` in error boundaries
* Update `server/appHandler.tsx`
  * Detect data router redirects, if they exist send a redirect response
  * If the handler query returns an http `Response` object (cannot be used to create a router) send a 500 redirect to `/error`
  * Refactor method of detecting a 404 router response
    * [Array.find()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find) exits early if a match is found, while [Array.reduce()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reduce) does not.
    * Suppy a [onShellError](https://react.dev/reference/react-dom/server/renderToPipeableStream#recovering-from-errors-inside-the-shell) option to [renderToPipeableStream](https://react.dev/reference/react-dom/server/renderToPipeableStream) call - if triggered this will redirect the response to the `/error` route

## Steps to QA
* Pull down and switch to this branch
* Update a page (ex: `/pages/Home`) to throw an error on render
  * Build and run the app, navigate to the changed page in the browser and ensure the server logs an error, and the page redirects to `/error`
  * Use links on the webpage to navigate away from and then to the page with error (client-side routing), ensure the error page renders even though the route is not `/error`
    * Error should be logged to browser console