### PR TITLE
Add documentation: Error Boundary and `withErrorBoundary()`

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -37,6 +37,7 @@
 * [Running the Application](#running-the-application)
 * [Project Directories](#project-directories)
 * [Adding an Application Directory](#adding-an-application-directory)
+* [Error Boundary](#error-boundary)
 * [Testing](#testing)
 * [Pull Request Template](#pull-request-template)
 * [Github Workflow](#github-workflow)
@@ -74,6 +75,31 @@ If any directory is removed, or if a new directory needs an alias:
 * The alias should be updated in the [paths configuration](https://www.typescriptlang.org/tsconfig#paths) for TypeScript to avoid type errors.
 * The alias should be updated in the [moduleNameMapper configuration](https://jestjs.io/docs/configuration#modulenamemapper-objectstring-string--arraystring) in the [Jest configuration](../jest.config.js) to ensure module mocking will work in tests, and so there are no errors in using the alias.
 * The directory should be updated in the `appConfig`·`testMatch` array to ensure that test runner knows which directories to cover.
+
+### Error Boundary
+**Tamsui** implements a basic [React Error Boundary](https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary) in [app/ErrorBoundary](../app/ErrorBoundary). This error boundary is configured as the [errorElement](https://reactrouter.com/en/main/route/error-element) in the [dataRoutes](../app/dataRoutes). It is recommended to wrap all root routes in this error boundary. An utility, [withErrorBoundary](../app/dataRoutes/withErrorBoundary.tsx), is provided to more easily (and declaratively) extend routes with this errorElement when extending routes:
+
+```javascript
+// app/dataRoutes/index.ts
+import withErrorBoundary from './withErrorBoundary';
+
+import PageComponent from 'pages/PageComponent';
+
+const dataRoutes = [
+  withErrorBoundary({
+    path: '/path-to-page',
+    Component: PageComponent,
+  }),
+];
+```
+
+On the server, if an error in rendering the application occurs it will redirect the request to `/error`, [configured by default](../server/appHandler.tsx) to the be [application's error page](../pages/ErrorPage).
+
+On the client, an error in a page will render the [ErrorPage component](../pages/ErrorPage) as fallback.
+
+**To change the path to the error page**: change the value of the constant `errorPagePath` in [server/appHandler.tsx](../server/appHandler.tsx). Make sure you define this route in the [app/dataRoutes/index.ts](../app/dataRoutes/index.ts) file.
+
+Alternatively, keep the error page path and just replace the [ErrorPage component](../pages/ErrorPage).
 
 ### Testing
 **Tamsui** utilizes [Jest](https://jestjs.io/) as test runner. Tests should be housed in a `__tests__/` directory and/or contain the extension `.test.js` anywhere within the [project directories](#project-directories).

--- a/server/appHandler.tsx
+++ b/server/appHandler.tsx
@@ -19,6 +19,7 @@ import manifest from './manifest';
 
 const handler = createStaticHandler(dataRoutes);
 const redirectCodes = [301, 302, 303, 307, 308];
+const errorPagePath = '/error';
 
 export default async function appHandler(req: Request, res: Response) {
   let errored = false;
@@ -51,7 +52,7 @@ export default async function appHandler(req: Request, res: Response) {
   if (contextIsResponse) {
     // Cannot create a static router if handler.query returned a Response object
     logger.error(new Error('Handler query returned a Response object'));
-    res.status(500).redirect('/error');
+    res.status(500).redirect(errorPagePath);
     return;
   }
 
@@ -82,7 +83,7 @@ export default async function appHandler(req: Request, res: Response) {
       },
       onShellError(err) {
         logger.error(err);
-        res.status(500).redirect('/error');
+        res.status(500).redirect(errorPagePath);
       },
       onError(err) {
         errored = true;


### PR DESCRIPTION
## Description
Linked to Issue: #67 
Documentation or the application's basic [Error Boundary](https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary), how it behaves, and how to use the routes helper utility `withErrorBoundary()`. Additionally, notes on how to change the default error route.

## Changes
* Add to documentation in `docs/README.md` a section `Error Boundary`
* Update `server/appHandler.tsx` to house a constant `errorPagePath` to house the string path to the error page

## Steps to QA
* Read over the documentation and ensure it covers the usage and needs
