### PR TITLE
Add Logo to `README.md` and favicon to site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,11 @@
-# Tamsui
+<div align="center">
+  <img width="200" height="200" alt="Tamsui logo" src="./static/images/logo.webp" /><br/>
+  <h1>Tamsui</h1>
+  <p>
+    Tamsui is an Express/TypeScript/React server-side rendered universal JavaScript application boilerplate.
+  </p>
+</div>
+
 **Tamsui** is a [Node.js](https://nodejs.org/en) boilerplate using [TypeScript](https://www.typescriptlang.org/) and [React](https://react.dev/). It provides server-side rendering using an [Express](https://expressjs.com/) webserver for a client-side [React](https://react.dev/) application.
 
 **Tamsui** renders to a React application to a [Node.js stream](https://nodejs.org/api/stream.html) utilizing React 18's [renderToPipeableStream method](https://react.dev/reference/react-dom/server/renderToPipeableStream).

--- a/app/App/__tests__/__snapshots__/index.test.js.snap
+++ b/app/App/__tests__/__snapshots__/index.test.js.snap
@@ -13,6 +13,27 @@ exports[`App Component matches child snapshot 1`] = `
       rel="stylesheet"
       type="text/css"
     />
+    <link
+      href="/static/images/favicon/apple-touch-icon.png"
+      rel="apple-touch-icon"
+      sizes="180x180"
+    />
+    <link
+      href="/static/images/favicon/favicon-32x32.png"
+      rel="icon"
+      sizes="32x32"
+      type="image/png"
+    />
+    <link
+      href="/static/images/favicon/favicon-16x16.png"
+      rel="icon"
+      sizes="16x16"
+      type="image/png"
+    />
+    <link
+      href="/static/site.webmanifest"
+      rel="manifest"
+    />
   </head>
   <body>
     <h1>
@@ -34,6 +55,27 @@ exports[`App Component matches no-child snapshot 1`] = `
       href="/Root CSS module"
       rel="stylesheet"
       type="text/css"
+    />
+    <link
+      href="/static/images/favicon/apple-touch-icon.png"
+      rel="apple-touch-icon"
+      sizes="180x180"
+    />
+    <link
+      href="/static/images/favicon/favicon-32x32.png"
+      rel="icon"
+      sizes="32x32"
+      type="image/png"
+    />
+    <link
+      href="/static/images/favicon/favicon-16x16.png"
+      rel="icon"
+      sizes="16x16"
+      type="image/png"
+    />
+    <link
+      href="/static/site.webmanifest"
+      rel="manifest"
     />
   </head>
   <body />

--- a/app/App/index.tsx
+++ b/app/App/index.tsx
@@ -14,6 +14,10 @@ export default function App({ manifest, children }: AppProps): React.ReactElemen
         <head>
           <title>Hello, React SSR!</title>
           <link rel="stylesheet" type="text/css" href={`/${manifest['app.css']}`} />
+          <link rel="apple-touch-icon" sizes="180x180" href="/static/images/favicon/apple-touch-icon.png" />
+          <link rel="icon" type="image/png" sizes="32x32" href="/static/images/favicon/favicon-32x32.png" />
+          <link rel="icon" type="image/png" sizes="16x16" href="/static/images/favicon/favicon-16x16.png" />
+          <link rel="manifest" href="/static/site.webmanifest" />
         </head>
         <body>
           { children }

--- a/pages/Home/__tests__/__snapshots__/index.test.js.snap
+++ b/pages/Home/__tests__/__snapshots__/index.test.js.snap
@@ -2,10 +2,15 @@
 
 exports[`Home Component matches snapshot 1`] = `
 <main>
+  <img
+    alt="Tamsui logo"
+    className="logo"
+    src="/static/images/logo.webp"
+  />
   <h1
     className="heading"
   >
-    Hello, React SSR!
+    Tamsui
   </h1>
   <a
     href="/counter"

--- a/pages/Home/__tests__/index.test.js
+++ b/pages/Home/__tests__/index.test.js
@@ -24,6 +24,6 @@ describe('Home Component', () => {
   test('contains the hello text', () => {
     render(<RouterWrappedHome />);
 
-    expect(screen.getByRole('heading')).toHaveTextContent('Hello, React SSR!');
+    expect(screen.getByRole('heading')).toHaveTextContent('Tamsui');
   });
 });

--- a/pages/Home/index.tsx
+++ b/pages/Home/index.tsx
@@ -6,7 +6,8 @@ import styles from './styles.module.scss';
 export default function Home(): React.ReactElement {
   return (
     <main>
-      <h1 className={styles.heading}>Hello, React SSR!</h1>
+      <img className={styles.logo} alt="Tamsui logo" src="/static/images/logo.webp" />
+      <h1 className={styles.heading}>Tamsui</h1>
       <Link to="/counter">React Counter</Link>
     </main>
   );

--- a/pages/Home/styles.module.scss
+++ b/pages/Home/styles.module.scss
@@ -1,3 +1,10 @@
+.logo {
+  display: block;
+  margin: 0 auto;
+  width: 200px;
+  height: auto;
+}
+
 .heading {
   text-align: center;  
 }


### PR DESCRIPTION
## Description
Linked to Issue: #59
Add the favicon to the boilerplate website, as well as the `/` root route. Additionally, add the Tamsui logo to the `README.md` file.

## Changes
* Add the Tamsui logo to the top of the `README.md` file
* Add favicon link tags to `app/App/index.tsx`
* Add Tamsui logo to `pages/Home/index.tsx`

## Steps to QA
* Pull down and switch to this branch
* Verify the Tamsui logo in the `README.md` looks good in the PR
* Run the app with `npm run dev`/`npm run watch`/`npm run prod`
* Verify in browser the favicon loads in the browser tab
* Verify the home route `/` displays the Tamsui logo