### PR TITLE
Fix: logo dimensions in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <img width="200" height="200" alt="Tamsui logo" src="./static/images/logo.webp" /><br/>
+  <img width="200" height="auto" alt="Tamsui logo" src="./static/images/logo.webp" /><br/>
   <h1>Tamsui</h1>
   <p>
     Tamsui is an Express/TypeScript/React server-side rendered universal JavaScript application boilerplate.


### PR DESCRIPTION
## Description
Linked to Issue: #59
The logo dimensions in `README.md` were fixed to 200x200 which caused some warping (the original image asset dimensions are not perfectly square). This sets the `height` attribute of the image to `auto`, ensuring the aspect ratio is preserved as `width` is set to `200`.

## Changes
* Change logo dimensions to `200`x`auto` in `README.md`

## Steps to QA
* Visually inspect the logo in the README file in this PR review
