### PR TITLE
Add MIT License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,7 @@
+Copyright (c) 2024 Chi-chi Wang <chichi@wangchiyi.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -40,3 +40,6 @@ Any non-trivial decisions made within this project will be documented. Technical
 
 ## Usage
 Usage documentation is provided in [docs/README.md](docs/README.md).
+
+## License
+[MIT](./LICENSE)


### PR DESCRIPTION
## Description
Linked to Issue: #72
Add a file `LICENSE` to the root directory containing the [MIT License](https://opensource.org/license/MIT) for this project.

## Changes
* Add a `LICENSE` file to the root project directory containing the MIT License
* Link to the license in the `README.md` file
* Remove the unused `exercise/` directory in the project root

## Steps to QA
* Verify the license looks correct

## After Merging
* [Apply the MIT License to the repository](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/licensing-a-repository#applying-a-license-to-a-repository-with-an-existing-license)