### PR TITLE
Center the contents of the Layout on screens larger than the max-width

### DIFF
--- a/pages/Layout/styles.module.scss
+++ b/pages/Layout/styles.module.scss
@@ -7,7 +7,8 @@
 }
 
 .content {
-  font-size: 1rem;
   max-width: map.get(var.$content, "max-width");
+  margin: 0 auto;
   padding-top: 5rem;
+  font-size: 1rem;
 }

--- a/pages/Layout/styles.nav.module.scss
+++ b/pages/Layout/styles.nav.module.scss
@@ -11,6 +11,7 @@ $section-border-size: 4px;
 .contents {
   display: flex;
   max-width: map.get(var.$content, "max-width");
+  margin: 0 auto;
 }
 
 .segment {


### PR DESCRIPTION
## Description
Linked to Issue: #75
The layout created in #77 was not centered within the screen when the screen size exceeds the `max-width` value of the content (1920px). This was not caught because the device used to develop that PR had a screen resolution of only 1920px, causing the page content to be justified to the left side of a very large screen. This PR remedies the issue.

## Changes
* Update styles in `pages/Layout/styles.module.scss` to center the content
* Update styles in `pages/Layout/styles.nav.module.scss` to center the content

## Steps to QA
* Pull down and switch to this branch
* Run the server (`npm run dev`/`npm run prod`/`npm run watch`) and verify in a browser, on a monitor whose resolution is greater than 1920px that the content is centered:

![image](https://github.com/chichiwang/tamsui/assets/2304118/3df5632b-1728-4539-a872-4f51b632332d)