### PR TITLE
Add viewport meta tag and CSS rules

### DIFF
--- a/app/App/__tests__/__snapshots__/index.test.js.snap
+++ b/app/App/__tests__/__snapshots__/index.test.js.snap
@@ -34,6 +34,10 @@ exports[`App Component matches child snapshot 1`] = `
       href="/static/site.webmanifest"
       rel="manifest"
     />
+    <meta
+      content="width=device-width"
+      name="viewport"
+    />
   </head>
   <body>
     <h1>
@@ -76,6 +80,10 @@ exports[`App Component matches no-child snapshot 1`] = `
     <link
       href="/static/site.webmanifest"
       rel="manifest"
+    />
+    <meta
+      content="width=device-width"
+      name="viewport"
     />
   </head>
   <body />

--- a/app/App/index.tsx
+++ b/app/App/index.tsx
@@ -18,6 +18,7 @@ export default function App({ manifest, children }: AppProps): React.ReactElemen
           <link rel="icon" type="image/png" sizes="32x32" href="/static/images/favicon/favicon-32x32.png" />
           <link rel="icon" type="image/png" sizes="16x16" href="/static/images/favicon/favicon-16x16.png" />
           <link rel="manifest" href="/static/site.webmanifest" />
+          <meta name="viewport" content="width=device-width" />
         </head>
         <body>
           { children }

--- a/app/global.module.scss
+++ b/app/global.module.scss
@@ -25,3 +25,11 @@
   text-decoration: none;
   font-weight: bold;
 }
+
+@viewport {
+  width: device-width;
+}
+
+@-ms-viewport {
+  width: device-width;
+}


### PR DESCRIPTION
## Description
Linked to Issue: #75
Add the [viewport meta tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Viewport_meta_tag) and [@viewport CSS rule](https://devdoc.net/web/developer.mozilla.org/en-US/docs/Web/CSS/@viewport.html) so that device browsers will treat the site as a responsive site.

## Changes
* Add [viewport meta tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Viewport_meta_tag) to the document head in `app/App/index.tsx`
* Add [@viewport CSS rule](https://devdoc.net/web/developer.mozilla.org/en-US/docs/Web/CSS/@viewport.html) to the global styles in `app/global.module.scss`
  * Add the same rule using the `-ms` IE vendor prefix

## Steps to QA
* Pull down and switch to this branch
* Run the app and verify in the browser, using device simulation (or create a [tunnel](https://localtunnel.github.io/www/) and verify on an actual mobile device) that the webpage does not render at a higher resolution and zoom out on mobile devices.
