### PR TITLE
Hide the nav bar on print

### DIFF
--- a/pages/Layout/styles.nav.module.scss
+++ b/pages/Layout/styles.nav.module.scss
@@ -62,3 +62,9 @@ $section-border-size: 4px;
     vertical-align: middle;
   }
 }
+
+@media print {
+  .navbar {
+    display: none;
+  }
+}


### PR DESCRIPTION
## Description
Linked to Issue: #75
Hide the navigation bar when printing the document, using [media queries](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_media_queries/Printing#using_media_queries_and_page_to_control_printed_content).

## Changes
* Set the display to `none` for the `.navbar` when the media is `print` in `pages/Layout/styles.nav.module.scss`

## Steps to QA
* Pull down and switch to this branch
* Run the application locally and navigate to any page in the application
* In developer tools, [emulate CSS media type](https://developer.chrome.com/docs/devtools/rendering/emulate-css/#emulate_css_media_type_enable_print_preview) to view the page as it would be printed (or just view the print menu preview in the browser)
* Ensure the navigation bar is not rendered in the above instances
