### PR TITLE
Do not hash CSS idents in development mode

### DIFF
--- a/webpack/rules/sass.loaders.js
+++ b/webpack/rules/sass.loaders.js
@@ -1,6 +1,11 @@
+const env = require('../env');
+
 const loaders = [{
   loader: 'css-loader',
   options: {
+    modules: {
+      localIdentName: env.isProd ? '[hash:base64]' : '[path][name]__[local]',
+    },
     sourceMap: true,
   },
 },


### PR DESCRIPTION
## Description
Linked to Issue: #85
Only hash CSS ident names in production mode - it is more useful to the development workflow to see the actual CSS ident names. [Webpack configurations for the CSS ident names](https://webpack.js.org/loaders/css-loader/#localidentname) are updated to show the css module file and ident name properly in non-production, but hash the ident in production.

## Changes
* Update CSS module configuration in `webpack/rules/sass.loaders.js` so that local idents are hashed in production, but displays the module path and ident name otherwise

## Steps to QA
* Pull down and switch to this branch
* Run the development build with `npm run watch`/`npm run dev`
  * Verify in the browser developer console that the class values for elements are not hashed values
![image](https://github.com/chichiwang/tamsui/assets/2304118/c5875885-920c-4cd5-85d2-9f696031d8da)
* Run the production build with `npm run prod`/`npm start`
  * Verify in the browser developer console that the class values for elements are hashed values
![image](https://github.com/chichiwang/tamsui/assets/2304118/13ec7374-bd74-4d6c-a53a-3f73f9ee3b96)

