### PR TITLE
Nav: Hide the home link text at small resolution sizes

### DIFF
--- a/app/var.module.scss
+++ b/app/var.module.scss
@@ -1,5 +1,8 @@
 @use "sass:map";
 
+$breakpoint-medium-min: 40rem;
+$breakpoint-small-max: 39.9375rem;
+
 $colors: (
   "black": #000,
   "white": #fff,

--- a/pages/Layout/styles.nav.module.scss
+++ b/pages/Layout/styles.nav.module.scss
@@ -28,6 +28,10 @@ $section-border-size: 4px;
     & span {
       margin: 0 calc(var.$spacing-unit / 2);
       vertical-align: middle;
+
+      @media (max-width: var.$breakpoint-small-max) {
+        display: none;
+      }
     }
   }
 


### PR DESCRIPTION
## Description
Linked to Issue: #83
Hide the "Tamsui" project name, in the home link, in the nav bar at lower screen resolutions.

## Changes
* Add variables to `app/var.module.scss`
  * `$breakpoint-medium-min`: Medium+ screen resolution min breakpoint
  * `$breakpoint-small-max`: Small screen resolution max breakpoint
* Set the "Tamsui" text container to display `none` at small screen sizes in `pages/Layout/styles.nav.module.scss`

## Steps to QA
* Pull down and switch to this branch
* Run the branch locally (`npm run watch`/`npm run dev`/`npm run prod`) and verify in browser that at 640px and above the nav bar contains the text "Tamsui" next to the logo:

![image](https://github.com/chichiwang/tamsui/assets/2304118/ca3fd9cd-1141-4c8b-a266-4173864af3c4)

* and the text disappears under 640px;

![image](https://github.com/chichiwang/tamsui/assets/2304118/8a374b17-12a8-44e3-87b8-53f6e9d56fd7)