### PR TITLE
Re-style Nav bar links

### DIFF
--- a/pages/Counter/__tests__/__snapshots__/index.test.js.snap
+++ b/pages/Counter/__tests__/__snapshots__/index.test.js.snap
@@ -141,6 +141,13 @@ exports[`Counter Component matches snapshot 1`] = `
         </a>
       </div>
     </div>
+    <div
+      className="accentBarContainer"
+    >
+      <div
+        className="accentBar slowSlide"
+      />
+    </div>
   </nav>
   <main
     className="content"

--- a/pages/ErrorPage/__tests__/__snapshots__/index.test.js.snap
+++ b/pages/ErrorPage/__tests__/__snapshots__/index.test.js.snap
@@ -141,6 +141,13 @@ exports[`ErrorPage Component matches snapshot 1`] = `
         </a>
       </div>
     </div>
+    <div
+      className="accentBarContainer"
+    >
+      <div
+        className="accentBar slowSlide"
+      />
+    </div>
   </nav>
   <main
     className="content"

--- a/pages/Home/__tests__/__snapshots__/index.test.js.snap
+++ b/pages/Home/__tests__/__snapshots__/index.test.js.snap
@@ -141,6 +141,13 @@ exports[`Home Component matches snapshot 1`] = `
         </a>
       </div>
     </div>
+    <div
+      className="accentBarContainer"
+    >
+      <div
+        className="accentBar slowSlide"
+      />
+    </div>
   </nav>
   <main
     className="content"

--- a/pages/Layout/Nav.tsx
+++ b/pages/Layout/Nav.tsx
@@ -27,6 +27,9 @@ function Nav() {
           </a>
         </div>
       </div>
+      <div className={styles.accentBarContainer}>
+        <div className={classNames(styles.accentBar, styles.slowSlide)} />
+      </div>
     </nav>
   );
 }

--- a/pages/Layout/__tests__/__snapshots__/Nav.test.js.snap
+++ b/pages/Layout/__tests__/__snapshots__/Nav.test.js.snap
@@ -50,5 +50,12 @@ exports[`Layout/Nav Component matches snapshot 1`] = `
       </a>
     </div>
   </div>
+  <div
+    className="accentBarContainer"
+  >
+    <div
+      className="accentBar slowSlide"
+    />
+  </div>
 </nav>
 `;

--- a/pages/Layout/__tests__/__snapshots__/index.test.js.snap
+++ b/pages/Layout/__tests__/__snapshots__/index.test.js.snap
@@ -141,6 +141,13 @@ exports[`Layout Component - default matches child snapshot 1`] = `
         </a>
       </div>
     </div>
+    <div
+      className="accentBarContainer"
+    >
+      <div
+        className="accentBar slowSlide"
+      />
+    </div>
   </nav>
   <main
     className="content"
@@ -292,6 +299,13 @@ exports[`Layout Component - default matches no-child snapshot 1`] = `
           />
         </a>
       </div>
+    </div>
+    <div
+      className="accentBarContainer"
+    >
+      <div
+        className="accentBar slowSlide"
+      />
     </div>
   </nav>
   <main

--- a/pages/Layout/styles.nav.module.scss
+++ b/pages/Layout/styles.nav.module.scss
@@ -1,11 +1,12 @@
 @use "sass:map";
 @use "app/var.module";
 
-$section-border-size: 4px;
+$accent-height: 4px;
 
 .navbar {
   width: 100%;
   font-size: 1.125rem;
+  overflow: hidden;
 }
 
 .contents {
@@ -23,7 +24,6 @@ $section-border-size: 4px;
   &.home {
     flex-grow: 1;
     justify-content: flex-start;
-    border-bottom: $section-border-size solid map.get(var.$colors, "maroon");
 
     & span {
       margin: 0 calc(var.$spacing-unit / 2);
@@ -39,13 +39,11 @@ $section-border-size: 4px;
     flex-grow: 1;
     justify-content: flex-end;
     padding-right: 2rem;
-    border-bottom: $section-border-size solid map.get(var.$colors, "red");
   }
 
   &.social {
     flex-grow: 0;
     justify-content: flex-end;
-    border-bottom: $section-border-size solid map.get(var.$colors, "orange");
 
     & .logo {
       width: auto;
@@ -64,8 +62,68 @@ $section-border-size: 4px;
   }
 }
 
+$accent-background-gradient: linear-gradient(
+  90deg,
+  map.get(var.$colors, 'maroon') 0% 25%,
+  map.get(var.$colors, 'red') 25% 50%,
+  map.get(var.$colors, 'orange') 50% 75%,
+  map.get(var.$colors, 'blue') 75% 100%,
+);
+
+.accentBarContainer {
+  position: relative;
+  width: 180%;
+  height: $accent-height;
+
+  & .accentBar {
+    position: absolute;
+    top: 0%;
+    left: 0%;
+    width: 100%;
+    height: 100%;
+    background: $accent-background-gradient;
+
+    &::before {
+      content: '';
+      position: absolute;
+      top: 0%;
+      left: 100%;
+      width: 100%;
+      height: 100%;
+      background: $accent-background-gradient;
+    }
+  }
+}
+
+/**
+ * Print styles
+ */
+
 @media print {
   .navbar {
     display: none;
+  }
+}
+
+/**
+ * Keyframe animations
+ */
+
+$slide-duration: 2400s;
+
+.slowSlide {
+  animation-name: slide-left;
+  animation-duration: $slide-duration;
+  animation-iteration-count: infinite;
+  animation-timing-function: linear;
+}
+
+@keyframes slide-left {
+  0% {
+    left: 0%;
+  }
+
+  100% {
+    left: -100%;
   }
 }

--- a/pages/Layout/styles.nav.module.scss
+++ b/pages/Layout/styles.nav.module.scss
@@ -16,12 +16,12 @@ $section-border-size: 4px;
 
 .segment {
   display: flex;
-  flex-basis: 33%;
-  flex-grow: 1;
+  flex-basis: auto;
   align-items: center;
   padding: calc(map.get(var.$content, "padding") / 2) map.get(var.$content, "padding");
 
   &.home {
+    flex-grow: 1;
     justify-content: flex-start;
     border-bottom: $section-border-size solid map.get(var.$colors, "maroon");
 
@@ -36,11 +36,14 @@ $section-border-size: 4px;
   }
 
   &.pages {
-    justify-content: center;
+    flex-grow: 1;
+    justify-content: flex-end;
+    padding-right: 2rem;
     border-bottom: $section-border-size solid map.get(var.$colors, "red");
   }
 
   &.social {
+    flex-grow: 0;
     justify-content: flex-end;
     border-bottom: $section-border-size solid map.get(var.$colors, "orange");
 

--- a/pages/NotFound/__tests__/__snapshots__/index.test.js.snap
+++ b/pages/NotFound/__tests__/__snapshots__/index.test.js.snap
@@ -141,6 +141,13 @@ exports[`NotFound Component matches snapshot 1`] = `
         </a>
       </div>
     </div>
+    <div
+      className="accentBarContainer"
+    >
+      <div
+        className="accentBar slowSlide"
+      />
+    </div>
   </nav>
   <main
     className="content"


### PR DESCRIPTION
## Description
Linked to Issue: #75
The site-wide `Nav` has page links centered. With only a single page link this looks strange, as if a site title. This PR moves the page links to the right side of the nav bar. It also removes the section accents (the colored borders under the segments) in favor of a subtly animated nav bar accent that runs under the nav bar.

## Changes
* Add an animated accent bar to `pages/Layout/Nav.tsx`
* Restyle segments in `pages/Layout/styles.nav.module.scss`
* Update snapshots for all pages that use the Layout

## Steps to QA
* Pull down and switch to this branch
* Verify the new Nav styles look alright
* If you wish the verify the entire animation, change `$slide-duration` CSS variable in `pages/Layout/styles.nav.module.scss` to a more reasonable timing for verification (like `5s`)
