### PR TITLE
Animated Logo: Print Styles

### DIFF
--- a/app/global.module.scss
+++ b/app/global.module.scss
@@ -9,6 +9,9 @@
 :global *:before,
 :global *:after {
   box-sizing: inherit;
+  -webkit-print-color-adjust: exact;
+  color-adjust: exact;
+  print-color-adjust: exact;
 }
 
 :global body {

--- a/pages/components/Logo/styles.module.scss
+++ b/pages/components/Logo/styles.module.scss
@@ -283,6 +283,16 @@ $outer-hex-diff-vertical: 1.8%; // as a % of the height of the outer container
 }
 
 /**
+ * Print styles
+ */
+
+@media print {
+  .spin {
+    animation: none;
+  }
+}
+
+/**
  * Keyframe animations
  */
 


### PR DESCRIPTION
## Description
Linked to Issue: #81
Turn off animation on the `AnimatedLogo` component for print styles.

## Changes
* Add a [print media query](rg/en-US/docs/Web/CSS/@media#media_types) to `pages/components/Logo/styles.module.scss` to set the animation `off`
* Set [print-color-adjust](https://developer.mozilla.org/en-US/docs/Web/CSS/print-color-adjust) to `exact` for all elements in `app/global.module.scss`
  * This ensures that browser print the page as styled, ensuring that background colors/images appear correctly.

## Steps to QA
* Pull down and switch to this branch
* In the browser, verify that the animation is turned off for print media
  * Either verify by opening the print preview window or
  * By [emulating the CSS media type for print](https://developer.chrome.com/docs/devtools/rendering/emulate-css/#emulate_css_media_type_enable_print_preview) in developer tools
