### PR TITLE
AnimatedLogo: Adjust `spin` animation to provide a bounce

### DIFF
--- a/pages/components/Logo/styles.module.scss
+++ b/pages/components/Logo/styles.module.scss
@@ -302,7 +302,7 @@ $animation-delay: 75ms;
   animation-name: spin;
   animation-duration: 9000ms;
   animation-iteration-count: infinite;
-  animation-timing-function: cubic-bezier(0.35, 0, 0.35, 0.78);
+  animation-timing-function: cubic-bezier(0.35, 1.64, 0.41, 0.8);
 }
 
 .delay1 {


### PR DESCRIPTION
## Description
Linked to Issue: #81 
Add a bounce to the end of the spin in the `AnimatedLogo` spin animation.

## Changes
* Adjust the styles on class `.spin` in `pages/components/Logo/styles.module.scss`
  * Adjust cubic-bezier easing function to provide a bounce at the end of the animation

## Steps to QA
* Pull down and switch to this branch
* Verify animation looks good in the browser
