### PR TITLE
Build Home page section: Mission Intent, What Tamsui Is Not

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,16 @@
   <img width="200" height="auto" alt="Tamsui logo" src="./logo.webp" /><br/>
   <h1>Tamsui</h1>
   <p>
-    Tamsui is an Express/TypeScript/React server-side rendered universal JavaScript application boilerplate.
+    Tamsui is an Express / TypeScript / React server-side rendered universal JavaScript application boilerplate.
   </p>
 </div>
 
-**Tamsui** is a [Node.js](https://nodejs.org/en) boilerplate using [TypeScript](https://www.typescriptlang.org/) and [React](https://react.dev/). It provides server-side rendering using an [Express](https://expressjs.com/) webserver for a client-side [React](https://react.dev/) application.
+**Tamsui** is a [Node.js](https://nodejs.org/en) boilerplate using [TypeScript](https://www.typescriptlang.org/) and [React](https://react.dev/). This boilerplate provides server-side rendering using an [Express](https://expressjs.com/) webserver for a client-side [React](https://react.dev/) application.
 
 **Tamsui** renders to a React application to a [Node.js stream](https://nodejs.org/api/stream.html) utilizing React 18's [renderToPipeableStream method](https://react.dev/reference/react-dom/server/renderToPipeableStream).
 
 ## Mission Intent
-**Tamsui** is meant to be a baseline boilerplate for future projects. The intent of this repository is to provide a thorough project start utilizing a specific set of tech stack and implemenentation decisions while remaining as simple as possible. This boilerplate will provide a foundation for building out a client with a webserver that acts as a [backend for frontend](https://learn.microsoft.com/en-us/azure/architecture/patterns/backends-for-frontends).
+**Tamsui** is meant to be a baseline boilerplate for starting new projects. The intent of this repository is to provide a thorough project start utilizing a specific set of tech stack and implemenentation decisions while remaining as simple as possible. This boilerplate will provide a foundation for building out a client served by a webserver that acts as a [backend for frontend](https://learn.microsoft.com/en-us/azure/architecture/patterns/backends-for-frontends).
 
 Documentation for this project will be thorough, test coverage will be complete. To that end unit test coverage requirements are set to 100% to start.
 

--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ Any non-trivial decisions made within this project will be documented. Technical
 
 **Client**
 * [React](https://react.dev/)
-* [Sass](https://sass-lang.com/)
 
 **Developer Tooling**
 * [TypeScript](https://www.typescriptlang.org/): Strict typing
+* [Sass](https://sass-lang.com/)
 * [Webpack](https://webpack.js.org/): Bundling
 * [Babel](https://babeljs.io/): Transpilation
 * [Jest](https://jestjs.io/): Testing

--- a/app/global.module.scss
+++ b/app/global.module.scss
@@ -29,6 +29,10 @@
   font-weight: bold;
 }
 
+:global h1 {
+  font-size: 2rem;
+}
+
 :global p {
   font-size: 1.125rem;
 }

--- a/app/types.ts
+++ b/app/types.ts
@@ -4,8 +4,9 @@ type Manifest = {
   'vendors.js': string;
 };
 
+type HeadingLevel = '1' | '2' | '3' | '4' | '5' | '6';
+
 export {
-  // Remove comment after adding more than one export
-  // eslint-disable-next-line
+  HeadingLevel,
   Manifest,
 };

--- a/pages/Home/__tests__/__snapshots__/index.test.js.snap
+++ b/pages/Home/__tests__/__snapshots__/index.test.js.snap
@@ -710,5 +710,54 @@ exports[`Home Component matches snapshot 1`] = `
       </p>
     </article>
   </section>,
+  <section
+    className="headingBlock"
+  >
+    <h2
+      className=""
+    >
+      Mission Intent
+    </h2>
+    <article>
+      <p>
+        Tamsui is meant to be a baseline boilerplate for starting new projects. 
+          The intent of this boilerplate is to provide a thorough project start 
+          utilizing a specific set of tech stack and implementation decisions while 
+          remaining as simple as possible. This boilerplate will provide a foundation 
+          for building out a client served by a webserver that acts as a 
+        <a
+          href="https://learn.microsoft.com/en-us/azure/architecture/patterns/backends-for-frontends"
+          rel="noreferrer"
+          target="blank"
+        >
+          backend for frontend
+        </a>
+        .
+      </p>
+      <p>
+        Documentation for this project will be thorough, test coverage will be complete. To that end unit tests coverage requirements are set to 100%.
+      </p>
+      <p>
+        Any non-trivial decisions made within this project will be documented. 
+          Technical decisions will be documented in 
+        <a
+          href="https://github.com/chichiwang/tamsui/pulls?q=is%3Aclosed"
+          rel="noreferrer"
+          target="_blank"
+        >
+          pull request descriptions
+        </a>
+        , project decisions documented in a 
+        <a
+          href="https://github.com/users/chichiwang/projects/1"
+          rel="noreferrer"
+          target="_blank"
+        >
+          project board
+        </a>
+        .
+      </p>
+    </article>
+  </section>,
 ]
 `;

--- a/pages/Home/__tests__/__snapshots__/index.test.js.snap
+++ b/pages/Home/__tests__/__snapshots__/index.test.js.snap
@@ -805,5 +805,86 @@ exports[`Home Component matches snapshot 1`] = `
       </p>
     </article>
   </section>,
+  <section
+    className="headingBlock"
+  >
+    <div
+      className="container"
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+    >
+      <div
+        className="wrapper"
+      >
+        <h3
+          className="tag"
+          id="What-Tamsui-Is-Not"
+        >
+          What Tamsui Is Not
+        </h3>
+        <a
+          aria-labelledby="What-Tamsui-Is-Not"
+          className="link"
+          href="#What-Tamsui-Is-Not"
+        >
+          <svg
+            height="1.75rem"
+            viewBox="0 0 24 24"
+            width="1.75rem"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g
+              fill="none"
+              stroke="currentColor"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2.5}
+            >
+              <path
+                d="M14 11.998C14 9.506 11.683 7 8.857 7H7.143C4.303 7 2 9.238 2 11.998c0 2.378 1.71 4.368 4 4.873a5.3 5.3 0 0 0 1.143.124"
+              />
+              <path
+                d="M10 11.998c0 2.491 2.317 4.997 5.143 4.997h1.714c2.84 0 5.143-2.237 5.143-4.997c0-2.379-1.71-4.37-4-4.874A5.3 5.3 0 0 0 16.857 7"
+              />
+            </g>
+          </svg>
+        </a>
+      </div>
+    </div>
+    <article>
+      <p>
+        Tamsui is an 
+        <a
+          href="https://en.wikipedia.org/wiki/Isomorphic_JavaScript"
+          rel="noreferrer"
+          target="_blank"
+        >
+          isomorphic JavaScript
+        </a>
+         application. The 
+        <a
+          href="https://expressjs.com/"
+          rel="noreferrer"
+          target="_blank"
+        >
+          Express
+        </a>
+         server that renders the application is intended to serve as a simple 
+        <a
+          href="https://learn.microsoft.com/en-us/azure/architecture/patterns/backends-for-frontends"
+          rel="noreferrer"
+          target="_blank"
+        >
+          backend for frontend
+        </a>
+        , not a full fledged backend for business logic.
+      </p>
+      <p>
+        Tamsui is meant to be a starting point for building a frontend layer, not an entire business application. 
+            Any backend API for managing business logic should not be built on top of Tamsui, and should exist outside 
+            of any application built on top of this boilerplate.
+      </p>
+    </article>
+  </section>,
 ]
 `;

--- a/pages/Home/__tests__/__snapshots__/index.test.js.snap
+++ b/pages/Home/__tests__/__snapshots__/index.test.js.snap
@@ -735,6 +735,33 @@ exports[`Home Component matches snapshot 1`] = `
         >
           Mission Intent
         </h2>
+        <a
+          aria-labelledby="Mission-Intent"
+          className="link"
+          href="#Mission-Intent"
+        >
+          <svg
+            height="1.75rem"
+            viewBox="0 0 24 24"
+            width="1.75rem"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g
+              fill="none"
+              stroke="currentColor"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2.5}
+            >
+              <path
+                d="M14 11.998C14 9.506 11.683 7 8.857 7H7.143C4.303 7 2 9.238 2 11.998c0 2.378 1.71 4.368 4 4.873a5.3 5.3 0 0 0 1.143.124"
+              />
+              <path
+                d="M10 11.998c0 2.491 2.317 4.997 5.143 4.997h1.714c2.84 0 5.143-2.237 5.143-4.997c0-2.379-1.71-4.37-4-4.874A5.3 5.3 0 0 0 16.857 7"
+              />
+            </g>
+          </svg>
+        </a>
       </div>
     </div>
     <article>

--- a/pages/Home/__tests__/__snapshots__/index.test.js.snap
+++ b/pages/Home/__tests__/__snapshots__/index.test.js.snap
@@ -635,11 +635,19 @@ exports[`Home Component matches snapshot 1`] = `
   <section
     className="headingBlock"
   >
-    <h1
-      className="center"
+    <div
+      className="container center"
     >
-      Tamsui
-    </h1>
+      <div
+        className="wrapper"
+      >
+        <h1
+          className="tag"
+        >
+          Tamsui
+        </h1>
+      </div>
+    </div>
     <article>
       <p
         className="tagline"
@@ -713,11 +721,22 @@ exports[`Home Component matches snapshot 1`] = `
   <section
     className="headingBlock"
   >
-    <h2
-      className=""
+    <div
+      className="container"
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
     >
-      Mission Intent
-    </h2>
+      <div
+        className="wrapper"
+      >
+        <h2
+          className="tag"
+          id="Mission-Intent"
+        >
+          Mission Intent
+        </h2>
+      </div>
+    </div>
     <article>
       <p>
         Tamsui is meant to be a baseline boilerplate for starting new projects. 

--- a/pages/Home/index.tsx
+++ b/pages/Home/index.tsx
@@ -41,7 +41,7 @@ function Home(): React.ReactElement {
 
       </HeadingBlock>
 
-      <HeadingBlock level="2" heading="Mission Intent">
+      <HeadingBlock id="Mission-Intent" level="2" heading="Mission Intent">
         <p>
           {`Tamsui is meant to be a baseline boilerplate for starting new projects. 
           The intent of this boilerplate is to provide a thorough project start 

--- a/pages/Home/index.tsx
+++ b/pages/Home/index.tsx
@@ -40,6 +40,32 @@ function Home(): React.ReactElement {
         </p>
 
       </HeadingBlock>
+
+      <HeadingBlock level="2" heading="Mission Intent">
+        <p>
+          {`Tamsui is meant to be a baseline boilerplate for starting new projects. 
+          The intent of this boilerplate is to provide a thorough project start 
+          utilizing a specific set of tech stack and implementation decisions while 
+          remaining as simple as possible. This boilerplate will provide a foundation 
+          for building out a client served by a webserver that acts as a `}
+          <a href="https://learn.microsoft.com/en-us/azure/architecture/patterns/backends-for-frontends" rel="noreferrer" target="blank">backend for frontend</a>
+          .
+        </p>
+
+        <p>
+          Documentation for this project will be thorough, test coverage will be complete.
+          To that end unit tests coverage requirements are set to 100%.
+        </p>
+
+        <p>
+          {`Any non-trivial decisions made within this project will be documented. 
+          Technical decisions will be documented in `}
+          <a href="https://github.com/chichiwang/tamsui/pulls?q=is%3Aclosed" rel="noreferrer" target="_blank">pull request descriptions</a>
+          {', project decisions documented in a '}
+          <a href="https://github.com/users/chichiwang/projects/1" rel="noreferrer" target="_blank">project board</a>
+          .
+        </p>
+      </HeadingBlock>
     </>
   );
 }

--- a/pages/Home/index.tsx
+++ b/pages/Home/index.tsx
@@ -66,6 +66,24 @@ function Home(): React.ReactElement {
           .
         </p>
       </HeadingBlock>
+
+      <HeadingBlock id="What-Tamsui-Is-Not" level="3" heading="What Tamsui Is Not">
+        <p>
+          {'Tamsui is an '}
+          <a href="https://en.wikipedia.org/wiki/Isomorphic_JavaScript" rel="noreferrer" target="_blank">isomorphic JavaScript</a>
+          {' application. The '}
+          <a href="https://expressjs.com/" rel="noreferrer" target="_blank">Express</a>
+          {' server that renders the application is intended to serve as a simple '}
+          <a href="https://learn.microsoft.com/en-us/azure/architecture/patterns/backends-for-frontends" rel="noreferrer" target="_blank">backend for frontend</a>
+          , not a full fledged backend for business logic.
+        </p>
+
+        <p>
+          {`Tamsui is meant to be a starting point for building a frontend layer, not an entire business application. 
+            Any backend API for managing business logic should not be built on top of Tamsui, and should exist outside 
+            of any application built on top of this boilerplate.`}
+        </p>
+      </HeadingBlock>
     </>
   );
 }

--- a/pages/components/Heading/__tests__/__snapshots__/index.test.js.snap
+++ b/pages/components/Heading/__tests__/__snapshots__/index.test.js.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Heading component matches className snapshot 1`] = `
+<h4
+  className="foobar"
+>
+  H1 Heading
+</h4>
+`;
+
+exports[`Heading component matches uncentered snapshot 1`] = `
+<h2
+  className=""
+>
+  H2 Heading
+</h2>
+`;

--- a/pages/components/Heading/__tests__/__snapshots__/index.test.js.snap
+++ b/pages/components/Heading/__tests__/__snapshots__/index.test.js.snap
@@ -1,17 +1,68 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Heading component matches className snapshot 1`] = `
-<h4
-  className="foobar"
+exports[`Heading component matches centered snapshot 1`] = `
+<div
+  className="container"
 >
-  H1 Heading
-</h4>
+  <div
+    className="wrapper"
+  >
+    <h6
+      className="tag"
+    >
+      H6 Heading centered
+    </h6>
+  </div>
+</div>
+`;
+
+exports[`Heading component matches className snapshot 1`] = `
+<div
+  className="container"
+>
+  <div
+    className="wrapper"
+  >
+    <h4
+      className="tag foobar"
+    >
+      H4 Heading with className
+    </h4>
+  </div>
+</div>
+`;
+
+exports[`Heading component matches id snapshot 1`] = `
+<div
+  className="container"
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+>
+  <div
+    className="wrapper"
+  >
+    <h2
+      className="tag"
+      id="FooBaz"
+    >
+      H2 Heading with ID
+    </h2>
+  </div>
+</div>
 `;
 
 exports[`Heading component matches uncentered snapshot 1`] = `
-<h2
-  className=""
+<div
+  className="container"
 >
-  H2 Heading
-</h2>
+  <div
+    className="wrapper"
+  >
+    <h2
+      className="tag"
+    >
+      H2 Heading
+    </h2>
+  </div>
+</div>
 `;

--- a/pages/components/Heading/__tests__/__snapshots__/index.test.js.snap
+++ b/pages/components/Heading/__tests__/__snapshots__/index.test.js.snap
@@ -47,6 +47,33 @@ exports[`Heading component matches id snapshot 1`] = `
     >
       H2 Heading with ID
     </h2>
+    <a
+      aria-labelledby="FooBaz"
+      className="link"
+      href="#FooBaz"
+    >
+      <svg
+        height="1.75rem"
+        viewBox="0 0 24 24"
+        width="1.75rem"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <g
+          fill="none"
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2.5}
+        >
+          <path
+            d="M14 11.998C14 9.506 11.683 7 8.857 7H7.143C4.303 7 2 9.238 2 11.998c0 2.378 1.71 4.368 4 4.873a5.3 5.3 0 0 0 1.143.124"
+          />
+          <path
+            d="M10 11.998c0 2.491 2.317 4.997 5.143 4.997h1.714c2.84 0 5.143-2.237 5.143-4.997c0-2.379-1.71-4.37-4-4.874A5.3 5.3 0 0 0 16.857 7"
+          />
+        </g>
+      </svg>
+    </a>
   </div>
 </div>
 `;

--- a/pages/components/Heading/__tests__/index.test.js
+++ b/pages/components/Heading/__tests__/index.test.js
@@ -1,0 +1,114 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import Heading from '../index';
+
+describe('Heading component', () => {
+  test('matches uncentered snapshot', () => {
+    const tree = renderer.create(
+      <Heading level="2">
+        H2 Heading
+      </Heading>,
+    ).toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('matches className snapshot', () => {
+    const tree = renderer.create(
+      <Heading level="4" className="foobar">
+        H1 Heading
+      </Heading>,
+    ).toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('renders child components', () => {
+    const childText = 'Paragraph Contents';
+
+    render(
+      <Heading level="3">
+        <p>{childText}</p>
+      </Heading>,
+    );
+
+    expect(screen.getByText(childText)).toBeInTheDocument();
+  });
+
+  describe('heading levels', () => {
+    test('contains a h1 tag', () => {
+      const headingText = 'H1 tag contents';
+
+      render(
+        <Heading level="1">
+          {headingText}
+        </Heading>,
+      );
+
+      expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(headingText);
+    });
+
+    test('contains a h2 tag', () => {
+      const headingText = 'H2 tag contents';
+
+      render(
+        <Heading level="2">
+          {headingText}
+        </Heading>,
+      );
+
+      expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent(headingText);
+    });
+
+    test('contains a h3 tag', () => {
+      const headingText = 'H3 tag contents';
+
+      render(
+        <Heading level="3">
+          {headingText}
+        </Heading>,
+      );
+
+      expect(screen.getByRole('heading', { level: 3 })).toHaveTextContent(headingText);
+    });
+
+    test('contains a h4 tag', () => {
+      const headingText = 'H4 tag contents';
+
+      render(
+        <Heading level="4">
+          {headingText}
+        </Heading>,
+      );
+
+      expect(screen.getByRole('heading', { level: 4 })).toHaveTextContent(headingText);
+    });
+
+    test('contains a h5 tag', () => {
+      const headingText = 'H4 tag contents';
+
+      render(
+        <Heading level="5">
+          {headingText}
+        </Heading>,
+      );
+
+      expect(screen.getByRole('heading', { level: 5 })).toHaveTextContent(headingText);
+    });
+
+    test('contains a h6 tag', () => {
+      const headingText = 'H6 tag contents';
+
+      render(
+        <Heading level="6">
+          {headingText}
+        </Heading>,
+      );
+
+      expect(screen.getByRole('heading', { level: 6 })).toHaveTextContent(headingText);
+    });
+  });
+});

--- a/pages/components/Heading/__tests__/index.test.js
+++ b/pages/components/Heading/__tests__/index.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 import Heading from '../index';
@@ -16,10 +16,30 @@ describe('Heading component', () => {
     expect(tree).toMatchSnapshot();
   });
 
+  test('matches centered snapshot', () => {
+    const tree = renderer.create(
+      <Heading level="6" centered>
+        H6 Heading centered
+      </Heading>,
+    ).toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+
   test('matches className snapshot', () => {
     const tree = renderer.create(
       <Heading level="4" className="foobar">
-        H1 Heading
+        H4 Heading with className
+      </Heading>,
+    ).toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('matches id snapshot', () => {
+    const tree = renderer.create(
+      <Heading id="FooBaz" level="2">
+        H2 Heading with ID
       </Heading>,
     ).toJSON();
 
@@ -109,6 +129,26 @@ describe('Heading component', () => {
       );
 
       expect(screen.getByRole('heading', { level: 6 })).toHaveTextContent(headingText);
+    });
+  });
+
+  describe('with ID', () => {
+    test('displays a link when hovered', async () => {
+      render(
+        <Heading id="Triggered Event" level="3">
+          Heading with ID
+        </Heading>,
+      );
+
+      fireEvent.mouseEnter(screen.getByRole('heading', { level: 3 }));
+      const link = await screen.queryByRole('link');
+
+      expect(link).toBeInTheDocument();
+
+      fireEvent.mouseLeave(screen.getByRole('heading', { level: 3 }));
+      const linkExit = await screen.queryByRole('link');
+
+      expect(linkExit).not.toBeInTheDocument();
     });
   });
 });

--- a/pages/components/Heading/__tests__/index.test.js
+++ b/pages/components/Heading/__tests__/index.test.js
@@ -134,21 +134,19 @@ describe('Heading component', () => {
 
   describe('with ID', () => {
     test('displays a link when hovered', async () => {
-      render(
+      const { container } = render(
         <Heading id="Triggered Event" level="3">
           Heading with ID
         </Heading>,
       );
 
       fireEvent.mouseEnter(screen.getByRole('heading', { level: 3 }));
-      const link = await screen.queryByRole('link');
 
-      expect(link).toBeInTheDocument();
+      expect(container.querySelector('.container').classList).toContain('hover');
 
       fireEvent.mouseLeave(screen.getByRole('heading', { level: 3 }));
-      const linkExit = await screen.queryByRole('link');
 
-      expect(linkExit).not.toBeInTheDocument();
+      expect(container.querySelector('.container').classList).not.toContain('hover');
     });
   });
 });

--- a/pages/components/Heading/index.tsx
+++ b/pages/components/Heading/index.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import classNames from 'classnames';
+
+import { HeadingLevel } from 'app/types';
+
+interface HeadingProps extends React.PropsWithChildren {
+  level: HeadingLevel,
+  className?: string,
+}
+
+function Heading({
+  level,
+  children,
+  className,
+}: HeadingProps) {
+  return React.createElement(
+    `h${level}`,
+    {
+      className: classNames(
+        className,
+      ),
+    },
+    children,
+  );
+}
+
+export default Heading;

--- a/pages/components/Heading/index.tsx
+++ b/pages/components/Heading/index.tsx
@@ -1,26 +1,70 @@
-import React from 'react';
+import React, { useState } from 'react';
 import classNames from 'classnames';
 
 import { HeadingLevel } from 'app/types';
 
+import styles from './styles.module.scss';
+
 interface HeadingProps extends React.PropsWithChildren {
-  level: HeadingLevel,
+  center?: boolean,
   className?: string,
+  id?: string,
+  level: HeadingLevel,
 }
 
 function Heading({
   level,
+  center = false,
   children,
   className,
+  id,
 }: HeadingProps) {
-  return React.createElement(
-    `h${level}`,
-    {
-      className: classNames(
-        className,
-      ),
-    },
-    children,
+  const [hovered, setHovered] = useState(false);
+
+  function onMouseEnter() {
+    setHovered(true);
+  }
+
+  function onMouseLeave() {
+    setHovered(false);
+  }
+
+  const containerProps = {
+    className: classNames(
+      styles.container,
+      {
+        [styles.center]: center,
+      },
+    ),
+    ...(typeof id === 'undefined' ? {} : {
+      onMouseEnter,
+      onMouseLeave,
+    }),
+  };
+
+  return (
+    <div {...containerProps}>
+      <div className={styles.wrapper}>
+        {
+          React.createElement(
+            `h${level}`,
+            {
+              ...(typeof id === 'undefined' ? {} : { id }),
+              className: classNames(
+                styles.tag,
+                className,
+              ),
+            },
+            children,
+          )
+        }
+        {
+          typeof id === 'undefined' || !hovered
+            ? null
+            : <a className={styles.link} href={`#${id}`}>🔗</a>
+        }
+      </div>
+    </div>
   );
 }
 

--- a/pages/components/Heading/index.tsx
+++ b/pages/components/Heading/index.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import classNames from 'classnames';
 
 import { HeadingLevel } from 'app/types';
+import LinkIcon from 'pages/components/LinkIcon';
 
 import styles from './styles.module.scss';
 
@@ -34,6 +35,7 @@ function Heading({
       styles.container,
       {
         [styles.center]: center,
+        [styles.hover]: hovered,
       },
     ),
     ...(typeof id === 'undefined' ? {} : {
@@ -59,9 +61,13 @@ function Heading({
           )
         }
         {
-          typeof id === 'undefined' || !hovered
+          typeof id === 'undefined'
             ? null
-            : <a className={styles.link} href={`#${id}`}>🔗</a>
+            : (
+              <a className={styles.link} href={`#${id}`} aria-labelledby={id}>
+                <LinkIcon width="1.75rem" height="1.75rem" />
+              </a>
+            )
         }
       </div>
     </div>

--- a/pages/components/Heading/styles.module.scss
+++ b/pages/components/Heading/styles.module.scss
@@ -1,0 +1,24 @@
+.container {
+  display: flex;
+  flex-direction: row;
+  justify-content: left;
+  
+  .wrapper {
+    position: relative;
+    display: flex;
+    align-items: center;
+
+    .tag {
+      display: inline-block;
+    }
+
+    .link {
+      position: absolute;
+      right: -30px;
+    }
+  }
+
+  &.center {
+    justify-content: center;
+  }
+}

--- a/pages/components/Heading/styles.module.scss
+++ b/pages/components/Heading/styles.module.scss
@@ -1,3 +1,6 @@
+@use "sass:map";
+@use "app/var.module";
+
 .container {
   display: flex;
   flex-direction: row;
@@ -14,11 +17,27 @@
 
     .link {
       position: absolute;
-      right: -30px;
+      height: 1.75rem;
+      right: -2.5rem;
+      pointer-events: none;
+      opacity: 0;
+      transform: rotateY(-180deg);
+      backface-visibility: hidden;
+      transition: opacity 1500ms ease-out, transform 850ms cubic-bezier(0.35, 1.64, 0.41, 0.8);
     }
   }
 
   &.center {
     justify-content: center;
+  }
+
+  &.hover {
+    .wrapper {
+      .link {
+        opacity: 1;
+        transform: rotateY(0deg);
+        pointer-events: auto;
+      }
+    }
   }
 }

--- a/pages/components/HeadingBlock/__tests__/__snapshots__/index.test.js.snap
+++ b/pages/components/HeadingBlock/__tests__/__snapshots__/index.test.js.snap
@@ -4,11 +4,19 @@ exports[`HeadingBlock Component matches centered snapshot 1`] = `
 <section
   className="headingBlock"
 >
-  <h1
-    className="center"
+  <div
+    className="container center"
   >
-    Test Heading
-  </h1>
+    <div
+      className="wrapper"
+    >
+      <h1
+        className="tag"
+      >
+        Test Heading
+      </h1>
+    </div>
+  </div>
   <article>
     <p>
       Block content
@@ -21,11 +29,19 @@ exports[`HeadingBlock Component matches uncentered snapshot 1`] = `
 <section
   className="headingBlock"
 >
-  <h1
-    className=""
+  <div
+    className="container"
   >
-    Test Heading
-  </h1>
+    <div
+      className="wrapper"
+    >
+      <h1
+        className="tag"
+      >
+        Test Heading
+      </h1>
+    </div>
+  </div>
   <article>
     <p>
       Block content

--- a/pages/components/HeadingBlock/__tests__/index.test.js
+++ b/pages/components/HeadingBlock/__tests__/index.test.js
@@ -39,76 +39,88 @@ describe('HeadingBlock Component', () => {
   });
 
   describe('heading levels', () => {
-    test('contains a h1 tag with the project name', () => {
+    test('contains a h1 tag', () => {
       const headingText = 'H1 tag contents';
+      const content = 'Block content';
 
       render(
         <HeadingBlock heading={headingText} level="1" center>
-          <p>Block content</p>
+          <p>{content}</p>
         </HeadingBlock>,
       );
 
       expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(headingText);
+      expect(screen.getByText(content)).toBeInTheDocument();
     });
 
-    test('contains a h2 tag with the project name', () => {
+    test('contains a h2', () => {
       const headingText = 'H2 tag contents';
+      const content = 'Block content';
 
       render(
         <HeadingBlock heading={headingText} level="2" center>
-          <p>Block content</p>
+          <p>{content}</p>
         </HeadingBlock>,
       );
 
       expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent(headingText);
+      expect(screen.getByText(content)).toBeInTheDocument();
     });
 
-    test('contains a h3 tag with the project name', () => {
+    test('contains a h3', () => {
       const headingText = 'H3 tag contents';
+      const content = 'Block content';
 
       render(
         <HeadingBlock heading={headingText} level="3" center>
-          <p>Block content</p>
+          <p>{content}</p>
         </HeadingBlock>,
       );
 
       expect(screen.getByRole('heading', { level: 3 })).toHaveTextContent(headingText);
+      expect(screen.getByText(content)).toBeInTheDocument();
     });
 
-    test('contains a h4 tag with the project name', () => {
+    test('contains a h4', () => {
       const headingText = 'H4 tag contents';
+      const content = 'Block content';
 
       render(
         <HeadingBlock heading={headingText} level="4" center>
-          <p>Block content</p>
+          <p>{content}</p>
         </HeadingBlock>,
       );
 
       expect(screen.getByRole('heading', { level: 4 })).toHaveTextContent(headingText);
+      expect(screen.getByText(content)).toBeInTheDocument();
     });
 
-    test('contains a h5 tag with the project name', () => {
+    test('contains a h5', () => {
       const headingText = 'H5 tag contents';
+      const content = 'Block content';
 
       render(
         <HeadingBlock heading={headingText} level="5" center>
-          <p>Block content</p>
+          <p>{content}</p>
         </HeadingBlock>,
       );
 
       expect(screen.getByRole('heading', { level: 5 })).toHaveTextContent(headingText);
+      expect(screen.getByText(content)).toBeInTheDocument();
     });
 
-    test('contains a h6 tag with the project name', () => {
+    test('contains a h6', () => {
       const headingText = 'H6 tag contents';
+      const content = 'Block content';
 
       render(
         <HeadingBlock heading={headingText} level="6" center>
-          <p>Block content</p>
+          <p>{content}</p>
         </HeadingBlock>,
       );
 
       expect(screen.getByRole('heading', { level: 6 })).toHaveTextContent(headingText);
+      expect(screen.getByText(content)).toBeInTheDocument();
     });
   });
 });

--- a/pages/components/HeadingBlock/index.tsx
+++ b/pages/components/HeadingBlock/index.tsx
@@ -7,19 +7,22 @@ import styles from './styles.module.scss';
 
 interface HeadingBlockProps extends React.PropsWithChildren {
   heading: string,
+  id?: string,
   level: HeadingLevel,
   center?: boolean,
 }
 
 function HeadingBlock({
   heading,
+  id,
   level,
   center = false,
   children,
 }: HeadingBlockProps) {
   const headingProps = {
+    center,
+    id,
     level,
-    ...(center ? { className: styles.center } : {}),
   };
 
   return (

--- a/pages/components/HeadingBlock/index.tsx
+++ b/pages/components/HeadingBlock/index.tsx
@@ -1,28 +1,14 @@
 import React from 'react';
-import classNames from 'classnames';
+
+import { HeadingLevel } from 'app/types';
+import Heading from 'pages/components/Heading';
 
 import styles from './styles.module.scss';
-
-type HeadingLevel = '1' | '2' | '3' | '4' | '5' | '6';
 
 interface HeadingBlockProps extends React.PropsWithChildren {
   heading: string,
   level: HeadingLevel,
   center?: boolean,
-}
-
-function createHeading(heading: string, level: HeadingLevel, center: boolean) {
-  return function DynamicHeading() {
-    return React.createElement(
-      `h${level}`,
-      {
-        className: classNames({
-          [styles.center]: center,
-        }),
-      },
-      heading,
-    );
-  };
 }
 
 function HeadingBlock({
@@ -31,11 +17,16 @@ function HeadingBlock({
   center = false,
   children,
 }: HeadingBlockProps) {
-  const SectionHeading = createHeading(heading, level, center);
+  const headingProps = {
+    level,
+    ...(center ? { className: styles.center } : {}),
+  };
 
   return (
     <section className={styles.headingBlock}>
-      <SectionHeading />
+      <Heading {...headingProps}>
+        {heading}
+      </Heading>
       <article>
         {children}
       </article>

--- a/pages/components/HeadingBlock/styles.module.scss
+++ b/pages/components/HeadingBlock/styles.module.scss
@@ -4,8 +4,8 @@
 $padding-unit: map.get(var.$content, 'padding');
 
 .headingBlock {
-  margin: 0 auto;
-  padding: calc(2 * $padding-unit) $padding-unit;
+  margin: calc(2 * $padding-unit) auto;
+  padding: 0 $padding-unit;
   max-width: map.get(var.$content, 'article-max-width');
 }
 

--- a/pages/components/HeadingBlock/styles.module.scss
+++ b/pages/components/HeadingBlock/styles.module.scss
@@ -8,7 +8,3 @@ $padding-unit: map.get(var.$content, 'padding');
   padding: 0 $padding-unit;
   max-width: map.get(var.$content, 'article-max-width');
 }
-
-.center {
-  text-align: center;
-}

--- a/pages/components/HeadingBlock/styles.module.scss
+++ b/pages/components/HeadingBlock/styles.module.scss
@@ -7,10 +7,6 @@ $padding-unit: map.get(var.$content, 'padding');
   margin: 0 auto;
   padding: calc(2 * $padding-unit) $padding-unit;
   max-width: map.get(var.$content, 'article-max-width');
-
-  h1 {
-    font-size: 2rem;
-  }
 }
 
 .center {

--- a/pages/components/LinkIcon/__tests__/__snapshots__/index.test.js.snap
+++ b/pages/components/LinkIcon/__tests__/__snapshots__/index.test.js.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`LinkIcon component matches the snapshot 1`] = `
+<svg
+  height="1em"
+  viewBox="0 0 24 24"
+  width="1em"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <g
+    fill="none"
+    stroke="currentColor"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    strokeWidth={2.5}
+  >
+    <path
+      d="M14 11.998C14 9.506 11.683 7 8.857 7H7.143C4.303 7 2 9.238 2 11.998c0 2.378 1.71 4.368 4 4.873a5.3 5.3 0 0 0 1.143.124"
+    />
+    <path
+      d="M10 11.998c0 2.491 2.317 4.997 5.143 4.997h1.714c2.84 0 5.143-2.237 5.143-4.997c0-2.379-1.71-4.37-4-4.874A5.3 5.3 0 0 0 16.857 7"
+    />
+  </g>
+</svg>
+`;

--- a/pages/components/LinkIcon/__tests__/index.test.js
+++ b/pages/components/LinkIcon/__tests__/index.test.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+
+import LinkIcon from '../index';
+
+describe('LinkIcon component', () => {
+  test('matches the snapshot', () => {
+    const tree = renderer.create(<LinkIcon />).toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/pages/components/LinkIcon/index.tsx
+++ b/pages/components/LinkIcon/index.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import type { SVGProps } from 'react';
+
+function LinkIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" {...props}>
+      <g fill="none" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5}>
+        <path d="M14 11.998C14 9.506 11.683 7 8.857 7H7.143C4.303 7 2 9.238 2 11.998c0 2.378 1.71 4.368 4 4.873a5.3 5.3 0 0 0 1.143.124" />
+        <path d="M10 11.998c0 2.491 2.317 4.997 5.143 4.997h1.714c2.84 0 5.143-2.237 5.143-4.997c0-2.379-1.71-4.37-4-4.874A5.3 5.3 0 0 0 16.857 7" />
+      </g>
+    </svg>
+  );
+}
+
+export default LinkIcon;


### PR DESCRIPTION
## Description
Linked to Issue: #76, #64
Add new section to `Home` page `/` component: "Mission Intent" (and sub-section: "What Tamsui Is Not"). In service of that goal, `HeadingBlock` component was refactored, and a sub-component `Heading` was broken out to provide more functionality (the ability to create an ID'd heading, which provides an anchor link to the heading itself).

## Changes
* `README.md` updated with minor copy changes so it may read a bit smoother
  * Under section "Technology Stack", Sass has been moved to "Developer Tooling" section where it belongs
    * While it serves the client, it is not a client runtime
* Set a font-size rule in `app/global.module.scss` for `h1` tags globally
* Type `HeadingLevel` added to `app/types.ts`
* New `HeadingBlock` sections added to `pages/Home/index.tsx`
  * Mission Intent: with an id
  * What Tamsui Is Not: with an id
* New component created `pages/components/Heading/index.tsx`
  * Renders a dynamic-level heading (1-6)
  * Option for styling the heading so it is centered
  * Option to provide an id to the heading
    * If an id is applied, mousing over the heading will reveal a link to the heading
* `pages/components/HeadingBlock/index.tsx` refactored to move responsibility for rendering the dynamic-level heading to the new `Heading` component
* Component `pages/components/LinkIcon/index.tsx` created to render an SVG icon of a link ([open source icon](https://icon-sets.iconify.design/iconoir/link/))
  * Used by the `Heading` component

## Steps to QA
* Pull down and switch to this branch
* Run the server locally, verify the home page `/` looks good and the documentation reads well in browser
  * Verify the link in the headings work correctly
* Review the revisions to the `README.md` file and ensure it reads well