### PR TITLE
ChecklistItem: Adjust vertical margin

### DIFF
--- a/pages/components/ChecklistItem/styles.module.scss
+++ b/pages/components/ChecklistItem/styles.module.scss
@@ -14,7 +14,7 @@ $opacity-duration: calc($grow-duration * 2);
 .checklistItem {
   position: relative;
   display: block;
-  margin: 0.25rem 0;
+  margin: 0.5rem 0;
 
   & > label {
     display: inline-block;


### PR DESCRIPTION
## Description
Linked to Issue: #65
Adjust vertical margin on `ChecklistItem` component from `0.25rem` to `0.5rem` to provide a bit more breathing room

## Changes
* Updated `pages/components/ChecklistItem/styles.module.scss` to adjust the vertical margin on `.checklistItem` element to `0.5rem`

## Steps to QA
* Pull down and switch to this branch
* Verify in browser on the `/documentation` page that the checklist items looks good and have a bit more breathing room between them
