### PR TITLE
Update `ChecklistItem`: Add strikethrough when checked

### DIFF
--- a/pages/components/ChecklistItem/styles.module.scss
+++ b/pages/components/ChecklistItem/styles.module.scss
@@ -170,6 +170,10 @@ $opacity-duration: calc($grow-duration * 2);
         opacity: 1;
       }
     }
+
+    &:checked ~ .labelContent {
+      text-decoration: line-through;
+    }
   }
 
   .labelContent {


### PR DESCRIPTION
## Description
Linked to Issue: #65 
Add a strikethrough to the label content of the `ChecklistItem` component when the checkbox is checked.

## Changes
* Update `pages/components/ChecklistItem` to apply a `text-decoration: line-through` rule to the label content when the input is checked

## Steps to QA
* Pull down and switch to this branch
* Verify in browser on the `/documentation` page that the checkbox item is struck-through when the checkbox gets checked
