### PR TITLE
Create components: `CopyIcon`, `CopyButton`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,7 +27,9 @@ module.exports = {
     parser: '@typescript-eslint/parser',
     plugins: ['@typescript-eslint'],
     rules: {
+      '@typescript-eslint/no-shadow': [2],
       '@typescript-eslint/no-unused-vars': 2,
+      'no-shadow': 0,
     },
   }],
   ignorePatterns: ['dist/**/*.*'],

--- a/app/var.module.scss
+++ b/app/var.module.scss
@@ -6,6 +6,7 @@ $breakpoint-small-max: 39.9375rem;
 $colors: (
   "black": #000,
   "white": #fff,
+  "grey": #949494,
   "blue": #4793AF,
   "orange": #FFC470,
   "red": #DD5746,

--- a/pages/Documentation/__tests__/__snapshots__/index.test.js.snap
+++ b/pages/Documentation/__tests__/__snapshots__/index.test.js.snap
@@ -689,5 +689,26 @@ exports[`Documentation Page Component matches snapshot 1`] = `
       </div>
     </article>
   </section>
+  <svg
+    height="1em"
+    viewBox="0 0 24 24"
+    width="1em"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <g
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+    >
+      <path
+        d="M7 9.667A2.667 2.667 0 0 1 9.667 7h8.666A2.667 2.667 0 0 1 21 9.667v8.666A2.667 2.667 0 0 1 18.333 21H9.667A2.667 2.667 0 0 1 7 18.333z"
+      />
+      <path
+        d="M4.012 16.737A2 2 0 0 1 3 15V5c0-1.1.9-2 2-2h10c.75 0 1.158.385 1.5 1"
+      />
+    </g>
+  </svg>
 </div>
 `;

--- a/pages/Documentation/__tests__/__snapshots__/index.test.js.snap
+++ b/pages/Documentation/__tests__/__snapshots__/index.test.js.snap
@@ -689,26 +689,60 @@ exports[`Documentation Page Component matches snapshot 1`] = `
       </div>
     </article>
   </section>
-  <svg
-    height="1em"
-    viewBox="0 0 24 24"
-    width="1em"
-    xmlns="http://www.w3.org/2000/svg"
+  <div
+    className="copyPosition"
   >
-    <g
-      fill="none"
-      stroke="currentColor"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      strokeWidth={2}
+    <div
+      className="copyContainer"
     >
-      <path
-        d="M7 9.667A2.667 2.667 0 0 1 9.667 7h8.666A2.667 2.667 0 0 1 21 9.667v8.666A2.667 2.667 0 0 1 18.333 21H9.667A2.667 2.667 0 0 1 7 18.333z"
-      />
-      <path
-        d="M4.012 16.737A2 2 0 0 1 3 15V5c0-1.1.9-2 2-2h10c.75 0 1.158.385 1.5 1"
-      />
-    </g>
-  </svg>
+      <div
+        className="message"
+      >
+        <div
+          className="successMessage"
+        >
+          <span>
+            Copied!
+          </span>
+        </div>
+        <div
+          className="errorMessage"
+        >
+          <span>
+            Failed!
+          </span>
+        </div>
+      </div>
+      <button
+        aria-label="Copy text"
+        className="copyButton"
+        onClick={[Function]}
+        type="button"
+      >
+        <svg
+          className="copyIcon"
+          height="1em"
+          viewBox="0 0 24 24"
+          width="1em"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <g
+            fill="none"
+            stroke="currentColor"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+          >
+            <path
+              d="M7 9.667A2.667 2.667 0 0 1 9.667 7h8.666A2.667 2.667 0 0 1 21 9.667v8.666A2.667 2.667 0 0 1 18.333 21H9.667A2.667 2.667 0 0 1 7 18.333z"
+            />
+            <path
+              d="M4.012 16.737A2 2 0 0 1 3 15V5c0-1.1.9-2 2-2h10c.75 0 1.158.385 1.5 1"
+            />
+          </g>
+        </svg>
+      </button>
+    </div>
+  </div>
 </div>
 `;

--- a/pages/Documentation/index.tsx
+++ b/pages/Documentation/index.tsx
@@ -6,6 +6,8 @@ import ExternalLink from 'pages/components/ExternalLink';
 import HeadingBlock from 'pages/components/HeadingBlock';
 import ChecklistItem from 'pages/components/ChecklistItem';
 
+import CopyIcon from 'pages/components/CopyIcon';
+
 import styles from './styles.module.scss';
 
 function Documentation() {
@@ -85,6 +87,8 @@ function Documentation() {
           .
         </ChecklistItem>
       </HeadingBlock>
+
+      <CopyIcon />
     </ContentBlock>
   );
 }

--- a/pages/Documentation/index.tsx
+++ b/pages/Documentation/index.tsx
@@ -6,7 +6,7 @@ import ExternalLink from 'pages/components/ExternalLink';
 import HeadingBlock from 'pages/components/HeadingBlock';
 import ChecklistItem from 'pages/components/ChecklistItem';
 
-import CopyIcon from 'pages/components/CopyIcon';
+import CopyButton from 'pages/components/CopyButton';
 
 import styles from './styles.module.scss';
 
@@ -88,7 +88,7 @@ function Documentation() {
         </ChecklistItem>
       </HeadingBlock>
 
-      <CopyIcon />
+      <CopyButton textToCopy="Hello, Documentation!" />
     </ContentBlock>
   );
 }

--- a/pages/Documentation/styles.module.scss
+++ b/pages/Documentation/styles.module.scss
@@ -2,7 +2,6 @@
 @use 'app/var.module';
 
 $indent-unit: map.get(var.$content, 'padding');
-$highlight-color: rgba(125, 125, 125, 0.8);
 
 .indent {
   margin-left: $indent-unit;
@@ -16,5 +15,5 @@ $highlight-color: rgba(125, 125, 125, 0.8);
   padding: calc(map.get(var.$content, 'padding') / 8) calc(map.get(var.$content, 'padding') / 4);
   color: map.get(var.$colors, 'white');
   border-radius: 0.25rem;
-  background-color: $highlight-color;
+  background-color: map.get(var.$colors, 'grey');
 }

--- a/pages/components/CopyButton/__tests__/__snapshots__/index.test.js.snap
+++ b/pages/components/CopyButton/__tests__/__snapshots__/index.test.js.snap
@@ -1,0 +1,59 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CopyButton component matches the snapshot 1`] = `
+<div
+  className="copyPosition"
+>
+  <div
+    className="copyContainer"
+  >
+    <div
+      className="message"
+    >
+      <div
+        className="successMessage"
+      >
+        <span>
+          Copied!
+        </span>
+      </div>
+      <div
+        className="errorMessage"
+      >
+        <span>
+          Failed!
+        </span>
+      </div>
+    </div>
+    <button
+      aria-label="Copy text"
+      className="copyButton"
+      onClick={[Function]}
+      type="button"
+    >
+      <svg
+        className="copyIcon"
+        height="1em"
+        viewBox="0 0 24 24"
+        width="1em"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <g
+          fill="none"
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+        >
+          <path
+            d="M7 9.667A2.667 2.667 0 0 1 9.667 7h8.666A2.667 2.667 0 0 1 21 9.667v8.666A2.667 2.667 0 0 1 18.333 21H9.667A2.667 2.667 0 0 1 7 18.333z"
+          />
+          <path
+            d="M4.012 16.737A2 2 0 0 1 3 15V5c0-1.1.9-2 2-2h10c.75 0 1.158.385 1.5 1"
+          />
+        </g>
+      </svg>
+    </button>
+  </div>
+</div>
+`;

--- a/pages/components/CopyButton/__tests__/index.test.js
+++ b/pages/components/CopyButton/__tests__/index.test.js
@@ -1,0 +1,126 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import CopyButton from '../index';
+
+jest.useFakeTimers();
+
+describe('CopyButton component', () => {
+  const WriteTextResolved = Promise.resolve(true);
+  const mockClipboard = {
+    writeText: jest.fn().mockReturnValue(WriteTextResolved),
+  };
+
+  beforeAll(() => {
+    global.navigator.clipboard = mockClipboard;
+    jest.spyOn(global, 'setTimeout');
+  });
+
+  beforeEach(() => {
+    global.navigator.clipboard.writeText.mockClear();
+    global.setTimeout.mockClear();
+  });
+
+  afterAll(() => {
+    delete global.navigator.clipBoard;
+    global.setTimeout.mockRestore();
+  });
+
+  test('matches the snapshot', () => {
+    const tree = renderer.create(
+      <CopyButton textToCopy="SecretCode" />,
+    ).toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('sends text to clipboard API when clicked', async () => {
+    const textToCopy = '(288) 555-0153';
+
+    render(<CopyButton textToCopy={textToCopy} />);
+
+    const $button = screen.getByRole('button');
+    const { queryByText: queryButtonText } = within($button);
+
+    expect(queryButtonText('⋯')).not.toBeInTheDocument();
+    expect(mockClipboard.writeText).toHaveBeenCalledTimes(0);
+
+    fireEvent.click($button);
+
+    expect(mockClipboard.writeText).toHaveBeenCalledTimes(1);
+    expect(mockClipboard.writeText).toHaveBeenCalledWith(textToCopy);
+    expect(queryButtonText('⋯')).toBeInTheDocument();
+
+    await act(() => WriteTextResolved);
+
+    expect(queryButtonText('✓')).toBeInTheDocument();
+
+    await act(() => jest.runAllTimers());
+
+    expect(global.setTimeout).toHaveBeenCalledTimes(1);
+    expect(queryButtonText('⋯')).not.toBeInTheDocument();
+    expect(queryButtonText('✓')).not.toBeInTheDocument();
+    expect(queryButtonText('!')).not.toBeInTheDocument();
+  });
+
+  describe('clipboard API errors', () => {
+    beforeAll(() => {
+      jest.spyOn(global.console, 'error');
+      global.console.error.mockImplementation(() => {});
+    });
+
+    beforeEach(() => {
+      global.console.error.mockClear();
+    });
+
+    afterAll(() => {
+      global.console.error.mockRestore();
+    });
+
+    test('logs error to console', async () => {
+      const textToCopy = 'EncryptionKey';
+      const ClipboardError = new Error('Browser took a poop');
+      const WriteTextRejected = Promise.reject(ClipboardError);
+      mockClipboard.writeText.mockReturnValueOnce(WriteTextRejected);
+
+      render(<CopyButton textToCopy={textToCopy} />);
+
+      const $button = screen.getByRole('button');
+      const { queryByText: queryButtonText } = within($button);
+
+      expect(mockClipboard.writeText).toHaveBeenCalledTimes(0);
+      expect(global.console.error).toHaveBeenCalledTimes(0);
+      expect(queryButtonText('⋯')).not.toBeInTheDocument();
+
+      fireEvent.click($button);
+
+      expect(queryButtonText('⋯')).toBeInTheDocument();
+
+      try {
+        await act(() => WriteTextRejected);
+      } catch (err) {
+        expect(mockClipboard.writeText).toHaveBeenCalledTimes(1);
+        expect(global.console.error).toHaveBeenCalledTimes(1);
+        expect(global.console.error).toHaveBeenCalledWith(ClipboardError);
+        expect(global.setTimeout).toHaveBeenCalledTimes(1);
+
+        await waitFor(() => expect(queryButtonText('!')).toBeInTheDocument());
+
+        await act(() => jest.runAllTimers());
+
+        expect(queryButtonText('⋯')).not.toBeInTheDocument();
+        expect(queryButtonText('✓')).not.toBeInTheDocument();
+        expect(queryButtonText('!')).not.toBeInTheDocument();
+      }
+    });
+  });
+});

--- a/pages/components/CopyButton/index.tsx
+++ b/pages/components/CopyButton/index.tsx
@@ -1,0 +1,90 @@
+import React, { useState } from 'react';
+import classNames from 'classnames';
+
+import CopyIcon from 'pages/components/CopyIcon';
+
+import styles from './styles.module.scss';
+
+type CopyButtonProps = {
+  textToCopy: string;
+};
+
+enum CopyStates {
+  ready,
+  copying,
+  copied,
+  errored
+}
+
+const ButtonContent = {
+  [CopyStates.ready]: (<CopyIcon className={styles.copyIcon} />),
+  [CopyStates.copying]: (<div className={styles.copyCharacter}>⋯</div>),
+  [CopyStates.copied]: (<div className={styles.copyCharacter}>✓</div>),
+  [CopyStates.errored]: (<div className={styles.copyCharacter}>!</div>),
+};
+
+const messageDisplayTime = 2000;
+
+function CopyButton({
+  textToCopy,
+}: CopyButtonProps) {
+  const [copyState, setCopyState] = useState(CopyStates.ready);
+
+  const isButtonDisabled = copyState !== CopyStates.ready;
+
+  function resetButton() {
+    setCopyState(CopyStates.ready);
+  }
+
+  function writeToClipboard() {
+    setCopyState(CopyStates.copying);
+
+    const writePromise = navigator.clipboard.writeText(textToCopy);
+
+    writePromise
+      .then(function writeComplete() {
+        setCopyState(CopyStates.copied);
+        setTimeout(resetButton, messageDisplayTime);
+      })
+      .catch(function writeFailed(err) {
+        console.error(err);
+        setCopyState(CopyStates.errored);
+        setTimeout(resetButton, messageDisplayTime);
+      });
+  }
+
+  const containerClassname = classNames({
+    [styles.copyContainer]: true,
+    [styles.disabled]: copyState === CopyStates.copying,
+    [styles.copied]: copyState === CopyStates.copied,
+    [styles.error]: copyState === CopyStates.errored,
+  });
+
+  const buttonProps = {
+    className: styles.copyButton,
+    'aria-label': 'Copy text',
+    ...(isButtonDisabled ? {} : {
+      onClick: writeToClipboard,
+    }),
+  };
+
+  return (
+    <div className={styles.copyPosition}>
+      <div className={containerClassname}>
+        <div className={styles.message}>
+          <div className={styles.successMessage}>
+            <span>Copied!</span>
+          </div>
+          <div className={styles.errorMessage}>
+            <span>Failed!</span>
+          </div>
+        </div>
+        <button type="button" {...buttonProps}>
+          { ButtonContent[copyState] }
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default CopyButton;

--- a/pages/components/CopyButton/index.tsx
+++ b/pages/components/CopyButton/index.tsx
@@ -18,9 +18,9 @@ enum CopyStates {
 
 const ButtonContent = {
   [CopyStates.ready]: (<CopyIcon className={styles.copyIcon} />),
-  [CopyStates.copying]: (<div className={styles.copyCharacter}>⋯</div>),
-  [CopyStates.copied]: (<div className={styles.copyCharacter}>✓</div>),
-  [CopyStates.errored]: (<div className={styles.copyCharacter}>!</div>),
+  [CopyStates.copying]: (<div className={styles.buttonContent}>⋯</div>),
+  [CopyStates.copied]: (<div className={styles.buttonContent}>✓</div>),
+  [CopyStates.errored]: (<div className={styles.buttonContent}>!</div>),
 };
 
 const messageDisplayTime = 2000;

--- a/pages/components/CopyButton/styles.module.scss
+++ b/pages/components/CopyButton/styles.module.scss
@@ -1,0 +1,137 @@
+@use 'sass:map';
+@use 'app/var.module';
+
+$padding-unit: map.get(var.$content, 'padding');
+
+$button-size: 1.75rem;
+$icon-size: 1.125rem;
+
+.copyPosition {
+  position: relative;
+  width: $button-size;
+  height: $button-size;
+
+  .copyContainer {
+    position: absolute;
+    display: flex;
+    top: 0;
+    right: 0;
+    font-size: 0;
+
+    .message {
+      position: relative;
+      height: $button-size;
+      user-select: none;
+      pointer-events: none;
+
+      .successMessage,
+      .errorMessage {
+        position: absolute;
+        top: 0;
+        right: 0.25rem;
+        display: flex;
+        align-items: center;
+        padding: calc($padding-unit / 4) calc($padding-unit / 2);
+        height: 100%;
+        color: map.get(var.$colors, 'white');
+        font-size: 0.75rem;
+        border-radius: 0.25rem;
+        transform: rotateY(-180deg);
+        transform-style: preserve-3d;
+        backface-visibility: hidden;
+        opacity: 0;
+        transition: opacity 1500ms ease-out, transform 850ms cubic-bezier(0.35, 1.64, 0.41, 0.8);
+      }
+
+      .successMessage {
+        background-color: map.get(var.$colors, 'blue');
+      }
+
+      .errorMessage {
+        background-color: map.get(var.$colors, 'maroon');
+      }
+    }
+
+    .copyButton {
+      display: flex;
+      align-items: center;
+      margin: 0;
+      padding: calc($padding-unit / 4);
+      width: $button-size;
+      height: $button-size;
+      border-radius: 0.25rem;
+      border: 1px solid map.get(var.$colors, 'blue');
+      background-color: transparent;
+      cursor: pointer;
+
+      .copyIcon {
+        width: $icon-size;
+        height: $icon-size;
+        color: map.get(var.$colors, 'blue');
+      }
+
+      .copyCharacter {
+        width: $icon-size;
+        height: $icon-size;
+        font-size: $icon-size;
+        font-weight: bold;
+        line-height: $icon-size;
+        color: map.get(var.$colors, 'white');
+      }
+
+      &:hover,
+      &:focus-visible {
+        border: 0;
+        background-color: map.get(var.$colors, 'blue');
+
+        .copyIcon {
+          color: map.get(var.$colors, 'white');
+        }
+      }
+    }
+
+    &.disabled .copyButton {
+      border: 0;
+      background-color: map.get(var.$colors, 'grey');
+      cursor: auto;
+
+      .copyIcon {
+        color: map.get(var.$colors, 'white');
+      }
+    }
+
+    &.copied {
+      .message .successMessage {
+        transform: rotateY(0deg);
+        opacity: 1;
+      }
+
+      .copyButton {
+        border: 0;
+        background-color: map.get(var.$colors, 'blue');
+        cursor: auto;
+
+        .copyIcon {
+          color: map.get(var.$colors, 'white');
+        }
+      }
+    }
+
+    &.error {
+      .message .errorMessage {
+        transform: rotateY(0deg);
+        opacity: 1;
+      }
+
+      .copyButton {
+        border: 0;
+        background-color: map.get(var.$colors, 'maroon');
+        cursor: auto;
+
+        .copyIcon {
+          color: map.get(var.$colors, 'white');
+        }
+      }
+    }
+  }
+}

--- a/pages/components/CopyButton/styles.module.scss
+++ b/pages/components/CopyButton/styles.module.scss
@@ -27,9 +27,9 @@ $icon-size: 1.125rem;
       .successMessage,
       .errorMessage {
         position: absolute;
+        display: flex;
         top: 0;
         right: 0.25rem;
-        display: flex;
         align-items: center;
         padding: calc($padding-unit / 4) calc($padding-unit / 2);
         height: 100%;
@@ -70,7 +70,7 @@ $icon-size: 1.125rem;
         color: map.get(var.$colors, 'blue');
       }
 
-      .copyCharacter {
+      .buttonContent {
         width: $icon-size;
         height: $icon-size;
         font-size: $icon-size;

--- a/pages/components/CopyIcon/__tests__/__snapshots__/index.test.js.snap
+++ b/pages/components/CopyIcon/__tests__/__snapshots__/index.test.js.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CopyIcon component matches the snapshot 1`] = `
+<svg
+  height="1em"
+  viewBox="0 0 24 24"
+  width="1em"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <g
+    fill="none"
+    stroke="currentColor"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    strokeWidth={2}
+  >
+    <path
+      d="M7 9.667A2.667 2.667 0 0 1 9.667 7h8.666A2.667 2.667 0 0 1 21 9.667v8.666A2.667 2.667 0 0 1 18.333 21H9.667A2.667 2.667 0 0 1 7 18.333z"
+    />
+    <path
+      d="M4.012 16.737A2 2 0 0 1 3 15V5c0-1.1.9-2 2-2h10c.75 0 1.158.385 1.5 1"
+    />
+  </g>
+</svg>
+`;

--- a/pages/components/CopyIcon/__tests__/index.test.js
+++ b/pages/components/CopyIcon/__tests__/index.test.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+
+import CopyIcon from '../index';
+
+describe('CopyIcon component', () => {
+  test('matches the snapshot', () => {
+    const tree = renderer.create(<CopyIcon />).toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/pages/components/CopyIcon/index.tsx
+++ b/pages/components/CopyIcon/index.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import type { SVGProps } from 'react';
+
+function CopyIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" {...props}>
+      <g fill="none" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}>
+        <path d="M7 9.667A2.667 2.667 0 0 1 9.667 7h8.666A2.667 2.667 0 0 1 21 9.667v8.666A2.667 2.667 0 0 1 18.333 21H9.667A2.667 2.667 0 0 1 7 18.333z" />
+        <path d="M4.012 16.737A2 2 0 0 1 3 15V5c0-1.1.9-2 2-2h10c.75 0 1.158.385 1.5 1" />
+      </g>
+    </svg>
+  );
+}
+
+export default CopyIcon;


### PR DESCRIPTION
## Description
Linked to Issue: #65 
Create a `CopyIcon` component (SVG of the copy icon) and a `CopyButton` component: a button pressed to copy some text to the system clipboard via the browser [Clipboard API](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard), specifically the [clipboard.writeText()](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard/writeText) method.

Additionally, `.eslintrc.js` has been updated to provide override rules for TypeScript files to turn off `no-shadow` and replaced with the `@typescript-eslint/no-shadow` rule. The `no-shadow` rule was [erroneously reporting errors](https://stackoverflow.com/questions/64463299/no-shadow-false-positive-when-declaring-any-typescript-enum-in-jhipster-app) when using [Enums](https://www.typescriptlang.org/docs/handbook/enums.html).

## Changes
* Update `.eslintrc.js` to provide overrides for `.ts`/`.tsx` files
  * Disable `no-shadow` rule
  * Enable `@typescript-eslint/no-shadow` rule
* Add `grey` to `$colors` in `app/var.module.scss`
* Render a `CopyButton` to `pages/Documentation/index.tsx` for development/testing
* Change `highlight` color to `var.$colors.grey` in `pages/Documentation/styles.mdoule.scss`
* Create a component `pages/components/CopyButton`
  * Render a button to copy text to system clipboard, text is provided via a prop `textToCopy`
  * Show a success/failure message on click of the button
* Create a component `pages/components/CopyIcon`
  * SVG of the copy icon sourced from [Iconify.design](https://icon-sets.iconify.design/tabler/copy/)

## Steps to QA
* Pull down and switch to this branch
* Run the app and verify in the browser:
  * Clicking on the copy button at the bottom of the `/documentation` route copies the text "Hello, Documentation!" to the system clipboard
  * Button is keyboard accessible (use Tab and Space keys to navigate to and engage the button)
  * Verification message and button-state appears, button resets after a short period
* Change the text passed to `CopyButton` in `pages/Documentation/index.tsx` and ensure this changes the text copied in browser
* Force a copy failure by editing `pages/components/CopyButton/index.tsx`:
  * Assign the `writePromise` variable in function `writeToClipboard()` to a Promise.reject (ex: `const writePromise = Promise.reject(new Error('Clipboard API failure!'));`
  * Click on the button in the browser and ensure the error message appears and looks correct