### PR TITLE
Make Copy button keyboard-accessible in NPM Script section of Documentation

### DIFF
--- a/pages/Documentation/styles.module.scss
+++ b/pages/Documentation/styles.module.scss
@@ -49,9 +49,13 @@ $indent-unit: map.get(var.$content, 'padding');
 
       & .copyButton {
         position: absolute;
-        display: none;
         top: 0;
         right: 0;
+        opacity: 0;
+
+        &:focus-within {
+          opacity: 1;
+        }
       }
 
       @media print,
@@ -71,7 +75,7 @@ $indent-unit: map.get(var.$content, 'padding');
 
   & tr:hover {
     & td .script .copyButton {
-      display: block;
+      opacity: 1;
 
       @media print,
       screen and (max-width: var.$breakpoint-small-max) {


### PR DESCRIPTION
## Description
Linked to Issue: #65 
Make keyboard navigation to the copy button in the "NPM Scripts" section of the `Documentation` page possible.

## Changes
* Update `pages/Documentation/styles.module.scss` so that the button is displayed in the document, but opacity is set to `0` until focused

## Steps to QA
* Pull down and switch to this branch
* Run the application
* Verify behavior in the browser on the `/documentation` page
  * Use `tab` to navigate accessible elements on the page
  * Tabbing into the "NPM Scripts" section should reveal the copy icons, space bar should trigger the icon to copy the script command
