### PR TITLE
Fix: Documentation page copy button visibility on keyboard navigation

### DIFF
--- a/pages/Documentation/styles.module.scss
+++ b/pages/Documentation/styles.module.scss
@@ -53,7 +53,7 @@ $indent-unit: map.get(var.$content, 'padding');
         right: 0;
         opacity: 0;
 
-        &:focus-within {
+        &:has(:focus-visible) {
           opacity: 1;
         }
       }


### PR DESCRIPTION
## Description
Linked to Issue: #46
The `.copyButton` class on the `/documentation` page is currently set up to be visible if it has [:focus-within](https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-within), which keeps the button visible after clicking (in addition to its intended behavior of making the button visible on keyboard navigation).

To make the button visible on keyboard navigation, but not persist its visibility on mouse click, [:has(:focus-visible)](https://larsmagnus.co/blog/focus-visible-within-the-missing-pseudo-class) should be used instead.

## Changes
* Update `pages/Documentation/styles.module.scss` to set `opacity: 1` for `.copyButton` on `:has(:focus-visible)` rather than `:focus-within`

## Steps to QA
* Pull down and switch to this branch
* Verify in the browser:
  * Copy button visibility does not persist on click any longer
  * Copy button continues to become visible on keyboard tab navigation