### PR TITLE
Add to Documentation page: Developing Locally, Running the Application, Project Directories, Adding an Application Directory

### DIFF
--- a/app/global.module.scss
+++ b/app/global.module.scss
@@ -35,6 +35,7 @@
 
 :global p {
   font-size: 1.125rem;
+  line-height: 1.5rem;
 }
 
 @viewport {

--- a/app/global.module.scss
+++ b/app/global.module.scss
@@ -16,7 +16,7 @@
 
 :global body {
   font-size: 16px;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue",sans-serif;
+  font-family: system-ui, sans-serif;
   margin: 0;
 }
 

--- a/app/var.module.scss
+++ b/app/var.module.scss
@@ -13,6 +13,13 @@ $colors: (
   "maroon": #8B322C,
 );
 
+$code-colors: (
+  "background": #434343,
+  "blue": #A5D6FF,
+  "red": #FF7B72,
+  "orange": #FFA657,
+);
+
 $spacing-unit: 1rem;
 
 $content: (

--- a/docs/README.md
+++ b/docs/README.md
@@ -78,7 +78,7 @@ If any directory is removed, or if a new directory needs an alias:
 * The [alias mapping](https://github.com/johvin/eslint-import-resolver-alias?tab=readme-ov-file#usage) should be added to the [eslint configuration](../.eslintrc.js) to avoid linting errors when using the alias.
 * The alias should be updated in the [paths configuration](https://www.typescriptlang.org/tsconfig#paths) for TypeScript to avoid type errors.
 * The alias should be updated in the [moduleNameMapper configuration](https://jestjs.io/docs/configuration#modulenamemapper-objectstring-string--arraystring) in the [Jest configuration](../jest.config.js) to ensure module mocking will work in tests, and so there are no errors in using the alias.
-* The directory should be updated in the `appConfig`·`testMatch` array to ensure that test runner knows which directories to cover.
+  * The directory should be updated in the `appConfig.testMatch` array to ensure that the test runner knows which directories to cover.
 
 ### Static Files
 The directory [static/](../static) housed in the project root is copied directly into the `dist/` directory on project build. This directory is served statically by the Express server.

--- a/docs/README.md
+++ b/docs/README.md
@@ -69,8 +69,7 @@ To add additional application directories, or to remove existing ones:
 The `app/` and `pages/` directories are set up with path aliases so that a module can be imported with absolute pathing rather than relative pathing:
 
 ```javascript
-import module from 'app/module';
-
+import Module from 'app/Module';
 import PageModule from 'pages/PageModule';
 ```
 

--- a/pages/Documentation/__tests__/__snapshots__/index.test.js.snap
+++ b/pages/Documentation/__tests__/__snapshots__/index.test.js.snap
@@ -2118,6 +2118,13 @@ exports[`Documentation Page Component matches snapshot 1`] = `
             Project Directories
           </a>
         </li>
+        <li>
+          <a
+            href="#Adding-an-Application-Directory"
+          >
+            Adding an Application Directory
+          </a>
+        </li>
       </ul>
     </article>
   </section>
@@ -2345,6 +2352,269 @@ exports[`Documentation Page Component matches snapshot 1`] = `
         </a>
          is implemented as the logger.
       </p>
+    </article>
+  </section>
+  <section
+    className="headingBlock"
+  >
+    <div
+      className="container"
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+    >
+      <div
+        className="wrapper"
+      >
+        <h3
+          className="tag"
+          id="Adding-an-Application-Directory"
+        >
+          Adding an Application Directory
+        </h3>
+        <a
+          aria-labelledby="Adding-an-Application-Directory"
+          className="link"
+          href="#Adding-an-Application-Directory"
+        >
+          <svg
+            height="1.75rem"
+            viewBox="0 0 24 24"
+            width="1.75rem"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g
+              fill="none"
+              stroke="currentColor"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2.5}
+            >
+              <path
+                d="M14 11.998C14 9.506 11.683 7 8.857 7H7.143C4.303 7 2 9.238 2 11.998c0 2.378 1.71 4.368 4 4.873a5.3 5.3 0 0 0 1.143.124"
+              />
+              <path
+                d="M10 11.998c0 2.491 2.317 4.997 5.143 4.997h1.714c2.84 0 5.143-2.237 5.143-4.997c0-2.379-1.71-4.37-4-4.874A5.3 5.3 0 0 0 16.857 7"
+              />
+            </g>
+          </svg>
+        </a>
+      </div>
+    </div>
+    <article>
+      <p>
+        To add additional application directories, or to remove existing ones:
+      </p>
+      <ul
+        className="list"
+      >
+        <li>
+          Path aliases need to be updated
+        </li>
+        <li>
+          Jest projects need to be updated
+        </li>
+      </ul>
+      <p>
+        The 
+        <span
+          className="highlight"
+        >
+          app/
+        </span>
+         and 
+        <span
+          className="highlight"
+        >
+          pages/
+        </span>
+         directories are set up with path aliases so that a module can be imported with
+           absolute pathing rather than relative pathing:
+      </p>
+      <div
+        className="codeBlock"
+      >
+        <div
+          className="copyPosition copyButton"
+        >
+          <div
+            className="copyContainer"
+          >
+            <div
+              className="message"
+            >
+              <div
+                className="successMessage"
+              >
+                <span>
+                  Copied!
+                </span>
+              </div>
+              <div
+                className="errorMessage"
+              >
+                <span>
+                  Failed!
+                </span>
+              </div>
+            </div>
+            <button
+              aria-label="Copy text"
+              className="copyButton"
+              onClick={[Function]}
+              type="button"
+            >
+              <svg
+                className="copyIcon"
+                height="1em"
+                viewBox="0 0 24 24"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <g
+                  fill="none"
+                  stroke="currentColor"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                >
+                  <path
+                    d="M7 9.667A2.667 2.667 0 0 1 9.667 7h8.666A2.667 2.667 0 0 1 21 9.667v8.666A2.667 2.667 0 0 1 18.333 21H9.667A2.667 2.667 0 0 1 7 18.333z"
+                  />
+                  <path
+                    d="M4.012 16.737A2 2 0 0 1 3 15V5c0-1.1.9-2 2-2h10c.75 0 1.158.385 1.5 1"
+                  />
+                </g>
+              </svg>
+            </button>
+          </div>
+        </div>
+        <p>
+          <span
+            className="red"
+          >
+            import
+          </span>
+           Module 
+          <span
+            className="red"
+          >
+            from
+          </span>
+           
+          <span
+            className="blue"
+          >
+            'app/module'
+          </span>
+          ;
+        </p>
+        <p>
+          <span
+            className="red"
+          >
+            import
+          </span>
+           PageModule 
+          <span
+            className="red"
+          >
+            from
+          </span>
+           
+          <span
+            className="blue"
+          >
+            'page/PageModule'
+          </span>
+          ;
+        </p>
+      </div>
+      <p>
+        If any directory is removed, or if a new directory needs an alias:
+      </p>
+      <ul
+        className="list"
+      >
+        <li>
+          An 
+          <span
+            className="highlight"
+          >
+            alias
+          </span>
+           should be updated in the 
+          <a
+            href="https://github.com/chichiwang/tamsui/blob/main/webpack/resolve.js"
+            rel="noreferrer"
+            target="_blank"
+          >
+            Webpack configs
+          </a>
+          .
+        </li>
+        <li>
+          The 
+          <a
+            href="https://github.com/johvin/eslint-import-resolver-alias?tab=readme-ov-file#usage"
+            rel="noreferrer"
+            target="_blank"
+          >
+            alias mapping
+          </a>
+           should be added to the 
+          <a
+            href="https://github.com/chichiwang/tamsui/blob/main/.eslintrc.js"
+            rel="noreferrer"
+            target="_blank"
+          >
+            eslint configuration
+          </a>
+           to avoid linting errors when using the alias.
+        </li>
+        <li>
+          The alias should be updated in the 
+          <a
+            href="https://www.typescriptlang.org/tsconfig#paths"
+            rel="noreferrer"
+            target="_blank"
+          >
+            paths configuration
+          </a>
+           for TypeScript to avoid type errors.
+        </li>
+        <li>
+          The alias should be updated in the 
+          <a
+            href="https://jestjs.io/docs/configuration#modulenamemapper-objectstring-string--arraystring"
+            rel="noreferrer"
+            target="_blank"
+          >
+            moduleNameMapper configuration
+          </a>
+           in the 
+          <a
+            href="https://github.com/chichiwang/tamsui/blob/main/jest.config.js"
+            rel="noreferrer"
+            target="_blank"
+          >
+            Jest configuration
+          </a>
+           to ensure module mocking will work in tests, and so there are no errors in using the alias.
+          <ul
+            className="list"
+          >
+            <li>
+              The directory should be updated in the 
+              <span
+                className="highlight"
+              >
+                appConfig.testMatch
+              </span>
+               array to ensure that the test runner knows which directories to cover.
+            </li>
+          </ul>
+        </li>
+      </ul>
     </article>
   </section>
 </div>

--- a/pages/Documentation/__tests__/__snapshots__/index.test.js.snap
+++ b/pages/Documentation/__tests__/__snapshots__/index.test.js.snap
@@ -60,7 +60,7 @@ exports[`Documentation Page Component matches snapshot 1`] = `
     </div>
     <article>
       <ul
-        className="contentList"
+        className="list content"
       >
         <li>
           <a
@@ -74,6 +74,13 @@ exports[`Documentation Page Component matches snapshot 1`] = `
             href="#NPM-Scripts"
           >
             NPM Scripts
+          </a>
+        </li>
+        <li>
+          <a
+            href="#Developing-Locally"
+          >
+            Developing Locally
           </a>
         </li>
       </ul>
@@ -2045,6 +2052,299 @@ exports[`Documentation Page Component matches snapshot 1`] = `
           </tr>
         </tbody>
       </table>
+    </article>
+  </section>
+  <section
+    className="headingBlock"
+  >
+    <div
+      className="container"
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+    >
+      <div
+        className="wrapper"
+      >
+        <h2
+          className="tag"
+          id="Developing-Locally"
+        >
+          Developing Locally
+        </h2>
+        <a
+          aria-labelledby="Developing-Locally"
+          className="link"
+          href="#Developing-Locally"
+        >
+          <svg
+            height="1.75rem"
+            viewBox="0 0 24 24"
+            width="1.75rem"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g
+              fill="none"
+              stroke="currentColor"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2.5}
+            >
+              <path
+                d="M14 11.998C14 9.506 11.683 7 8.857 7H7.143C4.303 7 2 9.238 2 11.998c0 2.378 1.71 4.368 4 4.873a5.3 5.3 0 0 0 1.143.124"
+              />
+              <path
+                d="M10 11.998c0 2.491 2.317 4.997 5.143 4.997h1.714c2.84 0 5.143-2.237 5.143-4.997c0-2.379-1.71-4.37-4-4.874A5.3 5.3 0 0 0 16.857 7"
+              />
+            </g>
+          </svg>
+        </a>
+      </div>
+    </div>
+    <article>
+      <ul
+        className="list content"
+      >
+        <li>
+          <a
+            href="#Running-the-Application"
+          >
+            Running the Application
+          </a>
+        </li>
+        <li>
+          <a
+            href="#Project-Directories"
+          >
+            Project Directories
+          </a>
+        </li>
+      </ul>
+    </article>
+  </section>
+  <section
+    className="headingBlock"
+  >
+    <div
+      className="container"
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+    >
+      <div
+        className="wrapper"
+      >
+        <h3
+          className="tag"
+          id="Running-the-Application"
+        >
+          Running the Application
+        </h3>
+        <a
+          aria-labelledby="Running-the-Application"
+          className="link"
+          href="#Running-the-Application"
+        >
+          <svg
+            height="1.75rem"
+            viewBox="0 0 24 24"
+            width="1.75rem"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g
+              fill="none"
+              stroke="currentColor"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2.5}
+            >
+              <path
+                d="M14 11.998C14 9.506 11.683 7 8.857 7H7.143C4.303 7 2 9.238 2 11.998c0 2.378 1.71 4.368 4 4.873a5.3 5.3 0 0 0 1.143.124"
+              />
+              <path
+                d="M10 11.998c0 2.491 2.317 4.997 5.143 4.997h1.714c2.84 0 5.143-2.237 5.143-4.997c0-2.379-1.71-4.37-4-4.874A5.3 5.3 0 0 0 16.857 7"
+              />
+            </g>
+          </svg>
+        </a>
+      </div>
+    </div>
+    <article>
+      <p>
+        Run 
+        <span
+          className="highlight"
+        >
+          npm run watch
+        </span>
+         to run the development watch server.
+      </p>
+      <p>
+        <span
+          className="highlight"
+        >
+          npm run dev
+        </span>
+         will build and run the application in development mode. 
+        <span
+          className="highlight"
+        >
+          npm run prod
+        </span>
+         will build and run the application in production mode. All of the above modes
+           will run the server output through 
+        <a
+          href="https://github.com/pinojs/pino-pretty"
+          rel="noreferrer"
+          target="_blank"
+        >
+          pino-pretty
+        </a>
+        .
+      </p>
+    </article>
+  </section>
+  <section
+    className="headingBlock"
+  >
+    <div
+      className="container"
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+    >
+      <div
+        className="wrapper"
+      >
+        <h3
+          className="tag"
+          id="Project-Directories"
+        >
+          Project Directories
+        </h3>
+        <a
+          aria-labelledby="Project-Directories"
+          className="link"
+          href="#Project-Directories"
+        >
+          <svg
+            height="1.75rem"
+            viewBox="0 0 24 24"
+            width="1.75rem"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g
+              fill="none"
+              stroke="currentColor"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2.5}
+            >
+              <path
+                d="M14 11.998C14 9.506 11.683 7 8.857 7H7.143C4.303 7 2 9.238 2 11.998c0 2.378 1.71 4.368 4 4.873a5.3 5.3 0 0 0 1.143.124"
+              />
+              <path
+                d="M10 11.998c0 2.491 2.317 4.997 5.143 4.997h1.714c2.84 0 5.143-2.237 5.143-4.997c0-2.379-1.71-4.37-4-4.874A5.3 5.3 0 0 0 16.857 7"
+              />
+            </g>
+          </svg>
+        </a>
+      </div>
+    </div>
+    <article>
+      <p>
+        The 
+        <span
+          className="highlight"
+        >
+          client/
+        </span>
+         directory is intended to house files specific to the client-side bundle.
+           At the moment it only contains the entrypoint file, which 
+        <a
+          href="https://react.dev/reference/react-dom/client/hydrateRoot"
+          rel="noreferrer"
+          target="_blank"
+        >
+          mounts and hydrates the root application
+        </a>
+        .
+      </p>
+      <p>
+        The 
+        <span
+          className="highlight"
+        >
+          app/
+        </span>
+         directory houses application-level concerns: the root application contains the
+           the html root, head, and body. The routes are housed in 
+        <a
+          href="https://github.com/chichiwang/tamsui/blob/main/app/dataRoutes"
+          rel="noreferrer"
+          target="_blank"
+        >
+          app/dataRoutes
+        </a>
+         as a 
+        <a
+          href="https://reactrouter.com/en/main/route/route"
+          rel="noreferrer"
+          target="_blank"
+        >
+          data routes object
+        </a>
+        . The reason the routes are not declared in 
+        <a
+          href="https://react.dev/learn/writing-markup-with-jsx"
+          rel="noreferrer"
+          target="_blank"
+        >
+          JSX
+        </a>
+         is for compatibility with rendering 
+        <a
+          href="https://react.dev/reference/react-dom/server/renderToPipeableStream"
+          rel="noreferrer"
+          target="_blank"
+        >
+          React to a Node.js stream
+        </a>
+        .
+      </p>
+      <p>
+        The 
+        <span
+          className="highlight"
+        >
+          pages/
+        </span>
+         directory houses the page-level react components. These are plugged into the
+           application via the 
+        <a
+          href="https://github.com/chichiwang/tamsui/blob/main/app/dataRoutes"
+          rel="noreferrer"
+          target="_blank"
+        >
+          dataRoutes object
+        </a>
+        .
+      </p>
+      <p>
+        The 
+        <span
+          className="highlight"
+        >
+          server/
+        </span>
+         directory houses the server-side rendering logic and defines the static asset
+           directories. 
+        <a
+          href="https://getpino.io/"
+          rel="noreferrer"
+          target="_blank"
+        >
+          Pino
+        </a>
+         is implemented as the logger.
+      </p>
     </article>
   </section>
 </div>

--- a/pages/Documentation/index.tsx
+++ b/pages/Documentation/index.tsx
@@ -368,10 +368,13 @@ function Documentation() {
           <li>
             <a href="#Running-the-Application">Running the Application</a>
           </li>
+          <li>
+            <a href="#Project-Directories">Project Directories</a>
+          </li>
         </ul>
       </HeadingBlock>
 
-      <HeadingBlock level="2" id="Running-the-Application" heading="Running the Application">
+      <HeadingBlock level="3" id="Running-the-Application" heading="Running the Application">
         <p>
           {'Run '}
           <span className={styles.highlight}>npm run watch</span>
@@ -385,6 +388,61 @@ function Documentation() {
            will run the server output through `}
           <ExternalLink href="https://github.com/pinojs/pino-pretty">pino-pretty</ExternalLink>
           .
+        </p>
+      </HeadingBlock>
+
+      <HeadingBlock level="3" id="Project-Directories" heading="Project Directories">
+        <p>
+          {'The '}
+          <span className={styles.highlight}>client/</span>
+          {` directory is intended to house files specific to the client-side bundle.
+           At the moment it only contains the entrypoint file, which `}
+          <ExternalLink href="https://react.dev/reference/react-dom/client/hydrateRoot">
+            mounts and hydrates the root application
+          </ExternalLink>
+          .
+        </p>
+        <p>
+          {'The '}
+          <span className={styles.highlight}>app/</span>
+          {` directory houses application-level concerns: the root application contains the
+           the html root, head, and body. The routes are housed in `}
+          <ExternalLink href="https://github.com/chichiwang/tamsui/blob/main/app/dataRoutes">
+            app/dataRoutes
+          </ExternalLink>
+          {' as a '}
+          <ExternalLink href="https://reactrouter.com/en/main/route/route">
+            data routes object
+          </ExternalLink>
+          {'. The reason the routes are not declared in '}
+          <ExternalLink href="https://react.dev/learn/writing-markup-with-jsx">
+            JSX
+          </ExternalLink>
+          {' is for compatibility with rendering '}
+          <ExternalLink href="https://react.dev/reference/react-dom/server/renderToPipeableStream">
+            React to a Node.js stream
+          </ExternalLink>
+          .
+        </p>
+        <p>
+          {'The '}
+          <span className={styles.highlight}>pages/</span>
+          {` directory houses the page-level react components. These are plugged into the
+           application via the `}
+          <ExternalLink href="https://github.com/chichiwang/tamsui/blob/main/app/dataRoutes">
+            dataRoutes object
+          </ExternalLink>
+          .
+        </p>
+        <p>
+          {'The '}
+          <span className={styles.highlight}>server/</span>
+          {` directory houses the server-side rendering logic and defines the static asset
+           directories. `}
+          <ExternalLink href="https://getpino.io/">
+            Pino
+          </ExternalLink>
+          {' is implemented as the logger.'}
         </p>
       </HeadingBlock>
     </ContentBlock>

--- a/pages/Documentation/index.tsx
+++ b/pages/Documentation/index.tsx
@@ -371,10 +371,17 @@ function Documentation() {
           <li>
             <a href="#Project-Directories">Project Directories</a>
           </li>
+          <li>
+            <a href="#Adding-an-Application-Directory">Adding an Application Directory</a>
+          </li>
         </ul>
       </HeadingBlock>
 
-      <HeadingBlock level="3" id="Running-the-Application" heading="Running the Application">
+      <HeadingBlock
+        level="3"
+        id="Running-the-Application"
+        heading="Running the Application"
+      >
         <p>
           {'Run '}
           <span className={styles.highlight}>npm run watch</span>
@@ -391,7 +398,11 @@ function Documentation() {
         </p>
       </HeadingBlock>
 
-      <HeadingBlock level="3" id="Project-Directories" heading="Project Directories">
+      <HeadingBlock
+        level="3"
+        id="Project-Directories"
+        heading="Project Directories"
+      >
         <p>
           {'The '}
           <span className={styles.highlight}>client/</span>
@@ -444,6 +455,105 @@ function Documentation() {
           </ExternalLink>
           {' is implemented as the logger.'}
         </p>
+      </HeadingBlock>
+
+      <HeadingBlock
+        level="3"
+        id="Adding-an-Application-Directory"
+        heading="Adding an Application Directory"
+      >
+        <p>
+          To add additional application directories, or to remove existing ones:
+        </p>
+
+        <ul className={styles.list}>
+          <li>Path aliases need to be updated</li>
+          <li>Jest projects need to be updated</li>
+        </ul>
+
+        <p>
+          {'The '}
+          <span className={styles.highlight}>app/</span>
+          {' and '}
+          <span className={styles.highlight}>pages/</span>
+          {` directories are set up with path aliases so that a module can be imported with
+           absolute pathing rather than relative pathing:`}
+        </p>
+
+        <div className={styles.codeBlock}>
+          <CopyButton
+            className={styles.copyButton}
+            textToCopy={'import Module from app/Module;\nimport PageModule from page/PageModule;'}
+          />
+          <p>
+            <span className={styles.red}>import</span>
+            {' Module '}
+            <span className={styles.red}>from</span>
+            {' '}
+            <span className={styles.blue}>&apos;app/module&apos;</span>
+            ;
+          </p>
+          <p>
+            <span className={styles.red}>import</span>
+            {' PageModule '}
+            <span className={styles.red}>from</span>
+            {' '}
+            <span className={styles.blue}>&apos;page/PageModule&apos;</span>
+            ;
+          </p>
+        </div>
+
+        <p>
+          If any directory is removed, or if a new directory needs an alias:
+        </p>
+
+        <ul className={styles.list}>
+          <li>
+            {'An '}
+            <span className={styles.highlight}>alias</span>
+            {' should be updated in the '}
+            <ExternalLink href="https://github.com/chichiwang/tamsui/blob/main/webpack/resolve.js">
+              Webpack configs
+            </ExternalLink>
+            .
+          </li>
+          <li>
+            {'The '}
+            <ExternalLink href="https://github.com/johvin/eslint-import-resolver-alias?tab=readme-ov-file#usage">
+              alias mapping
+            </ExternalLink>
+            {' should be added to the '}
+            <ExternalLink href="https://github.com/chichiwang/tamsui/blob/main/.eslintrc.js">
+              eslint configuration
+            </ExternalLink>
+            {' to avoid linting errors when using the alias.'}
+          </li>
+          <li>
+            {'The alias should be updated in the '}
+            <ExternalLink href="https://www.typescriptlang.org/tsconfig#paths">
+              paths configuration
+            </ExternalLink>
+            {' for TypeScript to avoid type errors.'}
+          </li>
+          <li>
+            {'The alias should be updated in the '}
+            <ExternalLink href="https://jestjs.io/docs/configuration#modulenamemapper-objectstring-string--arraystring">
+              moduleNameMapper configuration
+            </ExternalLink>
+            {' in the '}
+            <ExternalLink href="https://github.com/chichiwang/tamsui/blob/main/jest.config.js">
+              Jest configuration
+            </ExternalLink>
+            {' to ensure module mocking will work in tests, and so there are no errors in using the alias.'}
+            <ul className={styles.list}>
+              <li>
+                {'The directory should be updated in the '}
+                <span className={styles.highlight}>appConfig.testMatch</span>
+                {' array to ensure that the test runner knows which directories to cover.'}
+              </li>
+            </ul>
+          </li>
+        </ul>
       </HeadingBlock>
     </ContentBlock>
   );

--- a/pages/Documentation/index.tsx
+++ b/pages/Documentation/index.tsx
@@ -30,6 +30,9 @@ function Documentation() {
           <li>
             <a href="#NPM-Scripts">NPM Scripts</a>
           </li>
+          <li>
+            <a href="#Developing-Locally">Developing Locally</a>
+          </li>
         </ul>
       </HeadingBlock>
 
@@ -358,6 +361,31 @@ function Documentation() {
             </tr>
           </tbody>
         </table>
+      </HeadingBlock>
+
+      <HeadingBlock level="2" id="Developing-Locally" heading="Developing Locally">
+        <ul className={classNames(styles.list, styles.content)}>
+          <li>
+            <a href="#Running-the-Application">Running the Application</a>
+          </li>
+        </ul>
+      </HeadingBlock>
+
+      <HeadingBlock level="2" id="Running-the-Application" heading="Running the Application">
+        <p>
+          {'Run '}
+          <span className={styles.highlight}>npm run watch</span>
+          {' to run the development watch server.'}
+        </p>
+        <p>
+          <span className={styles.highlight}>npm run dev</span>
+          {' will build and run the application in development mode. '}
+          <span className={styles.highlight}>npm run prod</span>
+          {` will build and run the application in production mode. All of the above modes
+           will run the server output through `}
+          <ExternalLink href="https://github.com/pinojs/pino-pretty">pino-pretty</ExternalLink>
+          .
+        </p>
       </HeadingBlock>
     </ContentBlock>
   );

--- a/pages/Documentation/index.tsx
+++ b/pages/Documentation/index.tsx
@@ -23,7 +23,7 @@ function Documentation() {
       </HeadingBlock>
 
       <HeadingBlock level="2" heading="Contents">
-        <ul className={styles.contentList}>
+        <ul className={classNames(styles.list, styles.content)}>
           <li>
             <a href="#Starting-a-Project">Starting a Project</a>
           </li>

--- a/pages/Documentation/styles.module.scss
+++ b/pages/Documentation/styles.module.scss
@@ -18,9 +18,12 @@ $indent-unit: map.get(var.$content, 'padding');
   background-color: map.get(var.$colors, 'grey');
 }
 
-.contentList {
+.list {
   margin: 0;
-  list-style: none;
+
+  &.content {
+    list-style: none;
+  }
 
   & li {
     margin: calc(map.get(var.$content, 'padding') * 0.75) 0;

--- a/pages/Documentation/styles.module.scss
+++ b/pages/Documentation/styles.module.scss
@@ -88,6 +88,48 @@ $indent-unit: map.get(var.$content, 'padding');
   }
 }
 
+.codeBlock {
+  position: relative;
+  padding: map.get(var.$content, 'padding');
+  font-family: ui-monospace, 'Cascadia Code', 'Source Code Pro', Menlo, Consolas, 'DejaVu Sans Mono', monospace;
+  border-radius: 0.25rem;
+  background-color: map.get(var.$code-colors, 'background');
+
+  .copyButton {
+    position: absolute;
+    top: 1rem;
+    right: 1rem;
+
+    @media print,
+    screen and (max-width: var.$breakpoint-small-max) {
+      display: none;
+    }
+  }
+
+  p {
+    margin: 0;
+    color: map.get(var.$colors, 'white');
+  }
+
+  .red {
+    color: map.get(var.$code-colors, 'red');
+  }
+
+  .orange {
+    color: map.get(var.$colors, 'orange');
+  }
+
+  .blue {
+    color: map.get(var.$code-colors, 'blue');
+  }
+
+  @media screen and (max-width: var.$breakpoint-small-max) {
+    p {
+      font-size: 0.75rem;
+    }
+  }
+}
+
 @media print {
   .pageBreak {
     margin-top: 8rem;


### PR DESCRIPTION
## Description
Linked to Issue: #65 
Add sections to the `/documentation' page: Developing Locally, Running the Application, Project Directories, Adding an Application Directory.

Additionally, in doing so:
* Update default font-family for the `body` tag
* Grammatical fixes to `docs/README.md` in the "Adding an Application Directory" section

## Changes
* Update `app/global.module.scss`
  * Change the default `font-family` value for `body` tag (using values from [Modern Font Stacks](https://github.com/system-fonts/modern-font-stacks?tab=readme-ov-file))
  * Add a default `line-height` for `p` tags
* Add a `$code-colors` map to `app/var.module.scss` for use in code-blocks
* Grammatical fixes to `docs/README.md` in the section "Adding an Application Directory"
* Add sections to `pages/Documentation/index.tsx`
  * Developing Locally
  * Running the Application
  * Project Directories
  * Adding an Application Directory

## Steps to QA
* Verify the `docs/README.md` changes look good
* Pull down and switch to this branch
* Verify in browser:
  * Fonts look good on the `/`, '/error', not-found, and `/documentation` routes
  * Table of Content links work for the `/documentation` page
  * The new sections look good at various resolutions
  * The copy button in the code block in the "Adding an Application Directory" section properly copies the code displayed
  * The print preview looks good for the `/documentation` page