### PR TITLE
Add to Documentation page: Static Files, Error Boundary, Testing, Pull Request Template, Github Workflow

### DIFF
--- a/app/var.module.scss
+++ b/app/var.module.scss
@@ -16,8 +16,11 @@ $colors: (
 $code-colors: (
   "background": #434343,
   "blue": #A5D6FF,
-  "red": #FF7B72,
+  "darkBlue": #79c0ff,
+  "grey": #8B949E,
   "orange": #FFA657,
+  "purple": #D2A8FF,
+  "red": #FF7B72,
 );
 
 $spacing-unit: 1rem;

--- a/docs/README.md
+++ b/docs/README.md
@@ -93,13 +93,13 @@ On deployment, the `/dist/static/` directory can be uploaded to your CDN of choi
 - [ ] Add configuration options for serving built assets (`/scripts`, `/styles`) as well, so these assets can also be served via CDN
 
 ### Error Boundary
-**Tamsui** implements a basic [React Error Boundary](https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary) in [app/ErrorBoundary](../app/ErrorBoundary). This error boundary is configured as the [errorElement](https://reactrouter.com/en/main/route/error-element) in the [dataRoutes](../app/dataRoutes). It is recommended to wrap all root routes in this error boundary. An utility, [withErrorBoundary](../app/dataRoutes/withErrorBoundary.tsx), is provided to more easily (and declaratively) extend routes with this errorElement when extending routes:
+**Tamsui** implements a basic [React Error Boundary](https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary) in [app/ErrorBoundary](../app/ErrorBoundary). This error boundary is configured as an [errorElement](https://reactrouter.com/en/main/route/error-element) in the [dataRoutes](../app/dataRoutes) object. It is recommended all root routes are wrapped in this error boundary. A utility, [withErrorBoundary](../app/dataRoutes/withErrorBoundary.tsx), is provided to more easily (and declaratively) extend routes with this `errorElement` property:
 
 ```javascript
 // app/dataRoutes/index.ts
-import withErrorBoundary from './withErrorBoundary';
-
 import PageComponent from 'pages/PageComponent';
+
+import withErrorBoundary from './withErrorBoundary';
 
 const dataRoutes = [
   withErrorBoundary({
@@ -109,7 +109,7 @@ const dataRoutes = [
 ];
 ```
 
-On the server, if an error in rendering the application occurs it will redirect the request to `/error`, [configured by default](../server/appHandler.tsx) to the be [application's error page](../pages/ErrorPage).
+On the server, if an error in rendering the application occurs it will redirect the request to `/error`, [configured by default](../server/appHandler.tsx) to be the [application's error page](../pages/ErrorPage).
 
 On the client, an error in a page will render the [ErrorPage component](../pages/ErrorPage) as fallback.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -81,13 +81,13 @@ If any directory is removed, or if a new directory needs an alias:
   * The directory should be updated in the `appConfig.testMatch` array to ensure that the test runner knows which directories to cover.
 
 ### Static Files
-The directory [static/](../static) housed in the project root is copied directly into the `dist/` directory on project build. This directory is served statically by the Express server.
+The directory [static/](../static), housed in the project root, is copied directly into the `dist/` directory on project build. This directory is served statically by the Express server.
 
 This directory is meant to house static files (images, JSON files, etc.) used by **Tamsui**. This is a stop-gap solution: the Express server should not be used to serve static files like images - these should be housed in a CDN.
 
 On deployment, the `/dist/static/` directory can be uploaded to your CDN of choice.
 
-**TODO** (future tasks for the **Tamsui**):
+**TODO** (future tasks for the **Tamsui** project):
 - [ ] Add a configuration to provide a base route to static assets (so a CDN route can be provided)
 - [ ] Add a configuration to enable/disable serving `/static` directory files in various environments (development/production)
 - [ ] Add configuration options for serving built assets (`/scripts`, `/styles`) as well, so these assets can also be served via CDN

--- a/docs/README.md
+++ b/docs/README.md
@@ -118,11 +118,11 @@ On the client, an error in a page will render the [ErrorPage component](../pages
 Alternatively, keep the error page path and just replace the [ErrorPage component](../pages/ErrorPage).
 
 ### Testing
-**Tamsui** utilizes [Jest](https://jestjs.io/) as test runner. Tests should be housed in a `__tests__/` directory and/or contain the extension `.test.js` anywhere within the [project directories](#project-directories).
+**Tamsui** utilizes [Jest](https://jestjs.io/) as test runner. Tests should be housed in a `__tests__/` directory within their respective [project directories](#project-directories). Test files should have the file extension `.test.js`.
 
 The default [coverage threshhold](https://jestjs.io/docs/configuration#coveragethreshold-object) is set to 100% across the board. To reduce or remove the test coverage requirements, modify the `coverageThreshold` field in the [config](../jest.config.js).
 
-To run the test suite locally: `npm run test`. To update [Jest snapshots](https://jestjs.io/docs/snapshot-testing) `npm run test:snapshot` can be used. Alternatively, `npm run test -- -u` will also work.
+To run the test suite locally: `npm test`. To update [Jest snapshots](https://jestjs.io/docs/snapshot-testing) `npm run test:snapshot` can be used. Alternatively, `npm run test -- -u` will also work.
 
 ### Pull Request Template
 **Tamsui** contains a [Github Pull Request template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository) that is intended to provide a scaffold for a thorough pull request. [This template](../.github/pull_request_template.md) provides the following sections:

--- a/pages/Documentation/ErrorBoundary.tsx
+++ b/pages/Documentation/ErrorBoundary.tsx
@@ -1,0 +1,160 @@
+import React from 'react';
+import classNames from 'classnames';
+
+import HeadingBlock from 'app/components/HeadingBlock';
+import ExternalLink from 'app/components/ExternalLink';
+import CopyButton from 'app/components/CopyButton';
+
+import styles from './styles.module.scss';
+
+const errorBoundarySnippet = `// app/dataRoutes/index.ts
+import PageComponent from 'pages/pageComponent';
+
+import withErrorBoundary from './withErrorBoundary';
+
+const dataRoutes = [
+  withErrorBoundary({
+    path: '/path-to-page',
+    Component: PageComponent,
+  }),
+];`;
+
+function ErrorBoundary() {
+  return (
+    <HeadingBlock
+      level="3"
+      id="Error-Boundary"
+      heading="Error Boundary"
+    >
+      <p>
+        <b>Tamsui</b>
+        {' implements a basic '}
+        <ExternalLink href="https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary">
+          React Error Boundary
+        </ExternalLink>
+        {' in '}
+        <ExternalLink href="https://github.com/chichiwang/tamsui/blob/main/app/ErrorBoundary">
+          app/ErrorBoundary
+        </ExternalLink>
+        {'. This error boundary is configured as an '}
+        <ExternalLink href="https://reactrouter.com/en/main/route/error-element">
+          errorElement
+        </ExternalLink>
+        {' in the '}
+        <ExternalLink href="https://github.com/chichiwang/tamsui/blob/main/app/dataRoutes">
+          dataRoutes
+        </ExternalLink>
+        {' object. It is recommended all root routes are wrapped in this error boundary. A utility, '}
+        <ExternalLink href="https://github.com/chichiwang/tamsui/blob/main/app/dataRoutes/withErrorBoundary.tsx">
+          withErrorBoundary
+        </ExternalLink>
+        {' is provided to more easily (and declaratively) extend routes with this '}
+        <span className={styles.highlight}>errorElement</span>
+        {' property:'}
+      </p>
+
+      <div className={styles.codeBlock}>
+        <CopyButton className={styles.copyButton} textToCopy={errorBoundarySnippet} />
+        <p>
+          <span className={styles.grey}>&#47;&#47; app/dataRoutes/index.ts</span>
+        </p>
+        <p>
+          <span className={styles.red}>import</span>
+          {' '}
+          <span className={styles.orange}>PageComponent</span>
+          {' '}
+          <span className={styles.red}>from</span>
+          {' '}
+          <span className={styles.blue}>&apos;pages/PageComponent&apos;</span>
+          ;
+        </p>
+        <br />
+        <p>
+          <span className={styles.red}>import</span>
+          {' withErrorBoundary '}
+          <span className={styles.red}>from</span>
+          {' '}
+          <span className={styles.blue}>&apos;./withErrorBoundary&apos;</span>
+          ;
+        </p>
+        <br />
+        <p>
+          <span className={styles.red}>const</span>
+          {' dataRoutes '}
+          <span className={styles.blue}>=</span>
+          {' ['}
+        </p>
+        <p className={styles.indent}>
+          <span className={styles.purple}>withErrorBoundary</span>
+          (&#123;
+        </p>
+        <p className={classNames(styles.indent, styles.twice)}>
+          <span className={styles.darkBlue}>path</span>
+          {': '}
+          <span className={styles.blue}>&apos;/path-to-page&apos;</span>
+          ,
+        </p>
+        <p className={classNames(styles.indent, styles.twice)}>
+          <span className={styles.darkBlue}>Component</span>
+          {': '}
+          <span className={styles.orange}>PageComponent</span>
+          ,
+        </p>
+        <p className={styles.indent}>
+          &#125;),
+        </p>
+        <p>
+          ];
+        </p>
+      </div>
+
+      <p>
+        {`On the server, if an error in rendering the application occurs it will
+         redirect the request to `}
+        <span className={styles.highlight}>/error</span>
+        {', '}
+        <ExternalLink href="https://github.com/chichiwang/tamsui/blob/main/server/appHandler.tsx">
+          configured by default
+        </ExternalLink>
+        {' to be the '}
+        <ExternalLink href="https://github.com/chichiwang/tamsui/blob/main/pages/ErrorPage">
+          application&apos;s error page
+        </ExternalLink>
+        .
+      </p>
+
+      <p>
+        {'On the client, an error in a page will render the '}
+        <ExternalLink href="https://github.com/chichiwang/tamsui/blob/main/pages/ErrorPage">
+          ErrorPage component
+        </ExternalLink>
+        {' as fallback.'}
+      </p>
+
+      <p>
+        <b>To change the path to the error page</b>
+        {': change the value of the constant '}
+        <span className={styles.highlight}>errorPagePath</span>
+        {' in '}
+        <ExternalLink href="https://github.com/chichiwang/tamsui/blob/main/server/appHandler.tsx">
+          server/appHandler.tsx
+        </ExternalLink>
+        {'. Make sure you define this route in the '}
+        <ExternalLink href="https://github.com/chichiwang/tamsui/blob/main/app/dataRoutes/index.ts">
+          app/dataRoutes/index.ts
+        </ExternalLink>
+        {' file.'}
+      </p>
+
+      <p>
+        {'Alternatively, keep the error page path and just replace the '}
+        <ExternalLink href="https://github.com/chichiwang/tamsui/blob/main/pages/ErrorPage">
+          ErrorPage component
+        </ExternalLink>
+        .
+      </p>
+    </HeadingBlock>
+  );
+}
+
+export default ErrorBoundary;

--- a/pages/Documentation/GithubWorkflow.tsx
+++ b/pages/Documentation/GithubWorkflow.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+import HeadingBlock from 'app/components/HeadingBlock';
+import ExternalLink from 'app/components/ExternalLink';
+
+function GithubWorkflow() {
+  return (
+    <HeadingBlock
+      level="3"
+      id="Github-Workflow"
+      heading="Github Workflow"
+    >
+      <b>Tamsui</b>
+      {' contains a '}
+      <ExternalLink href="https://docs.github.com/en/actions/using-workflows/about-workflows">
+        Github workflow
+      </ExternalLink>
+      {' configured to '}
+      <ExternalLink href="https://github.com/chichiwang/tamsui/blob/main/.github/workflows/lint-test.yml">
+        run the linter and test runner
+      </ExternalLink>
+      {' on '}
+      <ExternalLink href="https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#push">
+        push events
+      </ExternalLink>
+      {'. If this is not desired, '}
+      <ExternalLink href="https://docs.github.com/en/actions/using-workflows/disabling-and-enabling-a-workflow#disabling-a-workflow">
+        disable the workflow in Github
+      </ExternalLink>
+      .
+    </HeadingBlock>
+  );
+}
+
+export default GithubWorkflow;

--- a/pages/Documentation/PullRequestTemplate.tsx
+++ b/pages/Documentation/PullRequestTemplate.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import classNames from 'classnames';
+
+import HeadingBlock from 'app/components/HeadingBlock';
+import ExternalLink from 'app/components/ExternalLink';
+
+import styles from './styles.module.scss';
+
+function PullRequestTemplate() {
+  return (
+    <HeadingBlock
+      level="3"
+      id="Pull-Request-Template"
+      heading="Pull Request Template"
+    >
+      <p>
+        <b>Tamsui</b>
+        {' contains a '}
+        <ExternalLink href="https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository">
+          Github Pull Request template
+        </ExternalLink>
+        {' that is intended to provide a scaffold for a thorough pull request. '}
+        <ExternalLink href="https://github.com/chichiwang/tamsui/blob/main/.github/pull_request_template.md">
+          This template
+        </ExternalLink>
+        {' provides the following sections:'}
+      </p>
+
+      <ul className={styles.list}>
+        <li>
+          <span className={styles.highlight}>Description</span>
+          :
+          <ul className={styles.list}>
+            <li>
+              {`Link to a related issue/story - important for documentation of
+               why this change is being made`}
+            </li>
+            <li>
+              A prompt to provide a description of the intent of the changes
+            </li>
+          </ul>
+        </li>
+        <li>
+          <span className={styles.highlight}>Changes</span>
+          : A prompt to list the code changes in the pull request
+        </li>
+        <li>
+          <span className={styles.highlight}>Steps to QA</span>
+          {`: A prompt to provide steps for reviewers to verify the changes
+           achieve their intended result`}
+        </li>
+      </ul>
+
+      <p>
+        The reason for these sections is two-fold:
+      </p>
+
+      <ul className={classNames(styles.list, styles.numbered)}>
+        <li>
+          {`Make it easier for reviewers to review the code changes, with full context of the reasons
+           the changes are being made, in order that the team can produce the best results for the codebase.`}
+        </li>
+        <li>
+          {`Provide a history of documentation in the repository, so that every significant change is
+           documented and vetted. This can be useful in the future to trace changes and intent when debugging
+           or extending the codebase.`}
+        </li>
+      </ul>
+    </HeadingBlock>
+  );
+}
+
+export default PullRequestTemplate;

--- a/pages/Documentation/StaticFiles.tsx
+++ b/pages/Documentation/StaticFiles.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+
+import HeadingBlock from 'app/components/HeadingBlock';
+import ExternalLink from 'app/components/ExternalLink';
+
+import styles from './styles.module.scss';
+
+function StaticFiles() {
+  return (
+    <HeadingBlock
+      level="3"
+      id="Static-Files"
+      heading="Static Files"
+    >
+      <p>
+        {'The directory '}
+        <ExternalLink href="https://github.com/chichiwang/tamsui/blob/main/static">
+          static/
+        </ExternalLink>
+        {', housed in the project root, is copied directly into the '}
+        <span className={styles.highlight}>dist/</span>
+        {` directory on the project build. This directory is served statically by the
+         Express server.`}
+      </p>
+
+      <p>
+        {'This directory is meant to house static files (images, JSON files, etc.) used by '}
+        <b>Tamsui</b>
+        {`. This is a stop-gap solution: the Express server should not be used to serve static
+         files like images - these should be housed in a CDN.`}
+      </p>
+
+      <p>
+        {'On deployment, the '}
+        <span className={styles.highlight}>/dist/static/</span>
+        {' directory can be uploaded to your CDN of choice.'}
+      </p>
+
+      <p>
+        <b>TODO</b>
+        {' (future tasks for the '}
+        <b>Tamsui</b>
+        {' project):'}
+      </p>
+
+      <ul className={styles.list}>
+        <li>
+          {`Add a configuration to provide a base route to static assets
+             (so a CDN route can be provided)`}
+        </li>
+        <li>
+          {'Add a configuration to enable/disable serving '}
+          <span className={styles.highlight}>/static</span>
+          {' directory files in various environments (development/production)'}
+        </li>
+        <li>
+          Add configuration options for serving built assets (
+          <span className={styles.highlight}>/scripts</span>
+          {', '}
+          <span className={styles.highlight}>/styles</span>
+          ) as well, so these assets can also be served via CDN
+        </li>
+      </ul>
+    </HeadingBlock>
+  );
+}
+
+export default StaticFiles;

--- a/pages/Documentation/Testing.tsx
+++ b/pages/Documentation/Testing.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+
+import HeadingBlock from 'app/components/HeadingBlock';
+import ExternalLink from 'app/components/ExternalLink';
+
+import styles from './styles.module.scss';
+
+function Testing() {
+  return (
+    <HeadingBlock
+      level="3"
+      id="Testing"
+      heading="Testing"
+    >
+      <p>
+        <b>Tamsui</b>
+        {' utilizes '}
+        <ExternalLink href="https://jestjs.io/">Jest</ExternalLink>
+        {' as a test runner. Tests should be housed in a '}
+        <span className={styles.highlight}>__tests__/</span>
+        {' directory within their respective '}
+        <a href="#Project-Directories">project directories</a>
+        {'. Test files should have the file extension '}
+        <span className={styles.highlight}>.test.js</span>
+      </p>
+
+      <p>
+        {'The default '}
+        <ExternalLink href="https://jestjs.io/docs/configuration#coveragethreshold-object">
+          coverage threshold
+        </ExternalLink>
+        {' is set too 100% across the board. To reduce or remove the coverage requirements, modify the '}
+        <span className={styles.highlight}>coverageThreshold</span>
+        {' field in the '}
+        <ExternalLink href="https://github.com/chichiwang/tamsui/blob/main/jest.config.js">
+          config
+        </ExternalLink>
+        .
+      </p>
+
+      <p>
+        {'To run the test suite locally: '}
+        <span className={styles.highlight}>npm test</span>
+        {'. To update '}
+        <ExternalLink href="https://jestjs.io/docs/snapshot-testing">
+          Jest snapshots
+        </ExternalLink>
+        {' '}
+        <span className={styles.highlight}>npm run test:snapshot</span>
+        {' can be used. Alternatively, '}
+        <span className={styles.highlight}>npm run test -- -u</span>
+        {' will also work.'}
+      </p>
+    </HeadingBlock>
+  );
+}
+
+export default Testing;

--- a/pages/Documentation/__tests__/__snapshots__/index.test.js.snap
+++ b/pages/Documentation/__tests__/__snapshots__/index.test.js.snap
@@ -2139,6 +2139,13 @@ exports[`Documentation Page Component matches snapshot 1`] = `
             Error Boundary
           </a>
         </li>
+        <li>
+          <a
+            href="#Testing"
+          >
+            Testing
+          </a>
+        </li>
       </ul>
     </article>
   </section>
@@ -3109,6 +3116,140 @@ exports[`Documentation Page Component matches snapshot 1`] = `
           ErrorPage component
         </a>
         .
+      </p>
+    </article>
+  </section>
+  <section
+    className="headingBlock"
+  >
+    <div
+      className="container"
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+    >
+      <div
+        className="wrapper"
+      >
+        <h3
+          className="tag"
+          id="Testing"
+        >
+          Testing
+        </h3>
+        <a
+          aria-labelledby="Testing"
+          className="link"
+          href="#Testing"
+        >
+          <svg
+            height="1.75rem"
+            viewBox="0 0 24 24"
+            width="1.75rem"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g
+              fill="none"
+              stroke="currentColor"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2.5}
+            >
+              <path
+                d="M14 11.998C14 9.506 11.683 7 8.857 7H7.143C4.303 7 2 9.238 2 11.998c0 2.378 1.71 4.368 4 4.873a5.3 5.3 0 0 0 1.143.124"
+              />
+              <path
+                d="M10 11.998c0 2.491 2.317 4.997 5.143 4.997h1.714c2.84 0 5.143-2.237 5.143-4.997c0-2.379-1.71-4.37-4-4.874A5.3 5.3 0 0 0 16.857 7"
+              />
+            </g>
+          </svg>
+        </a>
+      </div>
+    </div>
+    <article>
+      <p>
+        <b>
+          Tamsui
+        </b>
+         utilizes 
+        <a
+          href="https://jestjs.io/"
+          rel="noreferrer"
+          target="_blank"
+        >
+          Jest
+        </a>
+         as a test runner. Tests should be housed in a 
+        <span
+          className="highlight"
+        >
+          __tests__/
+        </span>
+         directory within their respective 
+        <a
+          href="#Project-Directories"
+        >
+          project directories
+        </a>
+        . Test files should have the file extension 
+        <span
+          className="highlight"
+        >
+          .test.js
+        </span>
+      </p>
+      <p>
+        The default 
+        <a
+          href="https://jestjs.io/docs/configuration#coveragethreshold-object"
+          rel="noreferrer"
+          target="_blank"
+        >
+          coverage threshold
+        </a>
+         is set too 100% across the board. To reduce or remove the coverage requirements, modify the 
+        <span
+          className="highlight"
+        >
+          coverageThreshold
+        </span>
+         field in the 
+        <a
+          href="https://github.com/chichiwang/tamsui/blob/main/jest.config.js"
+          rel="noreferrer"
+          target="_blank"
+        >
+          config
+        </a>
+        .
+      </p>
+      <p>
+        To run the test suite locally: 
+        <span
+          className="highlight"
+        >
+          npm test
+        </span>
+        . To update 
+        <a
+          href="https://jestjs.io/docs/snapshot-testing"
+          rel="noreferrer"
+          target="_blank"
+        >
+          Jest snapshots
+        </a>
+         
+        <span
+          className="highlight"
+        >
+          npm run test:snapshot
+        </span>
+         can be used. Alternatively, 
+        <span
+          className="highlight"
+        >
+          npm run test -- -u
+        </span>
+         will also work.
       </p>
     </article>
   </section>

--- a/pages/Documentation/__tests__/__snapshots__/index.test.js.snap
+++ b/pages/Documentation/__tests__/__snapshots__/index.test.js.snap
@@ -2132,6 +2132,13 @@ exports[`Documentation Page Component matches snapshot 1`] = `
             Static Files
           </a>
         </li>
+        <li>
+          <a
+            href="#Error-Boundary"
+          >
+            Error Boundary
+          </a>
+        </li>
       </ul>
     </article>
   </section>
@@ -2748,6 +2755,361 @@ exports[`Documentation Page Component matches snapshot 1`] = `
           ) as well, so these assets can also be served via CDN
         </li>
       </ul>
+    </article>
+  </section>
+  <section
+    className="headingBlock"
+  >
+    <div
+      className="container"
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+    >
+      <div
+        className="wrapper"
+      >
+        <h3
+          className="tag"
+          id="Error-Boundary"
+        >
+          Error Boundary
+        </h3>
+        <a
+          aria-labelledby="Error-Boundary"
+          className="link"
+          href="#Error-Boundary"
+        >
+          <svg
+            height="1.75rem"
+            viewBox="0 0 24 24"
+            width="1.75rem"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g
+              fill="none"
+              stroke="currentColor"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2.5}
+            >
+              <path
+                d="M14 11.998C14 9.506 11.683 7 8.857 7H7.143C4.303 7 2 9.238 2 11.998c0 2.378 1.71 4.368 4 4.873a5.3 5.3 0 0 0 1.143.124"
+              />
+              <path
+                d="M10 11.998c0 2.491 2.317 4.997 5.143 4.997h1.714c2.84 0 5.143-2.237 5.143-4.997c0-2.379-1.71-4.37-4-4.874A5.3 5.3 0 0 0 16.857 7"
+              />
+            </g>
+          </svg>
+        </a>
+      </div>
+    </div>
+    <article>
+      <p>
+        <b>
+          Tamsui
+        </b>
+         implements a basic 
+        <a
+          href="https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary"
+          rel="noreferrer"
+          target="_blank"
+        >
+          React Error Boundary
+        </a>
+         in 
+        <a
+          href="https://github.com/chichiwang/tamsui/blob/main/app/ErrorBoundary"
+          rel="noreferrer"
+          target="_blank"
+        >
+          app/ErrorBoundary
+        </a>
+        . This error boundary is configured as an 
+        <a
+          href="https://reactrouter.com/en/main/route/error-element"
+          rel="noreferrer"
+          target="_blank"
+        >
+          errorElement
+        </a>
+         in the 
+        <a
+          href="https://github.com/chichiwang/tamsui/blob/main/app/dataRoutes"
+          rel="noreferrer"
+          target="_blank"
+        >
+          dataRoutes
+        </a>
+         object. It is recommended all root routes are wrapped in this error boundary. A utility, 
+        <a
+          href="https://github.com/chichiwang/tamsui/blob/main/app/dataRoutes/withErrorBoundary.tsx"
+          rel="noreferrer"
+          target="_blank"
+        >
+          withErrorBoundary
+        </a>
+         is provided to more easily (and declaratively) extend routes with this 
+        <span
+          className="highlight"
+        >
+          errorElement
+        </span>
+         property:
+      </p>
+      <div
+        className="codeBlock"
+      >
+        <div
+          className="copyPosition copyButton"
+        >
+          <div
+            className="copyContainer"
+          >
+            <div
+              className="message"
+            >
+              <div
+                className="successMessage"
+              >
+                <span>
+                  Copied!
+                </span>
+              </div>
+              <div
+                className="errorMessage"
+              >
+                <span>
+                  Failed!
+                </span>
+              </div>
+            </div>
+            <button
+              aria-label="Copy text"
+              className="copyButton"
+              onClick={[Function]}
+              type="button"
+            >
+              <svg
+                className="copyIcon"
+                height="1em"
+                viewBox="0 0 24 24"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <g
+                  fill="none"
+                  stroke="currentColor"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                >
+                  <path
+                    d="M7 9.667A2.667 2.667 0 0 1 9.667 7h8.666A2.667 2.667 0 0 1 21 9.667v8.666A2.667 2.667 0 0 1 18.333 21H9.667A2.667 2.667 0 0 1 7 18.333z"
+                  />
+                  <path
+                    d="M4.012 16.737A2 2 0 0 1 3 15V5c0-1.1.9-2 2-2h10c.75 0 1.158.385 1.5 1"
+                  />
+                </g>
+              </svg>
+            </button>
+          </div>
+        </div>
+        <p>
+          <span
+            className="grey"
+          >
+            // app/dataRoutes/index.ts
+          </span>
+        </p>
+        <p>
+          <span
+            className="red"
+          >
+            import
+          </span>
+           
+          <span
+            className="orange"
+          >
+            PageComponent
+          </span>
+           
+          <span
+            className="red"
+          >
+            from
+          </span>
+           
+          <span
+            className="blue"
+          >
+            'pages/PageComponent'
+          </span>
+          ;
+        </p>
+        <br />
+        <p>
+          <span
+            className="red"
+          >
+            import
+          </span>
+           withErrorBoundary 
+          <span
+            className="red"
+          >
+            from
+          </span>
+           
+          <span
+            className="blue"
+          >
+            './withErrorBoundary'
+          </span>
+          ;
+        </p>
+        <br />
+        <p>
+          <span
+            className="red"
+          >
+            const
+          </span>
+           dataRoutes 
+          <span
+            className="blue"
+          >
+            =
+          </span>
+           [
+        </p>
+        <p
+          className="indent"
+        >
+          <span
+            className="purple"
+          >
+            withErrorBoundary
+          </span>
+          ({
+        </p>
+        <p
+          className="indent twice"
+        >
+          <span
+            className="darkBlue"
+          >
+            path
+          </span>
+          : 
+          <span
+            className="blue"
+          >
+            '/path-to-page'
+          </span>
+          ,
+        </p>
+        <p
+          className="indent twice"
+        >
+          <span
+            className="darkBlue"
+          >
+            Component
+          </span>
+          : 
+          <span
+            className="orange"
+          >
+            PageComponent
+          </span>
+          ,
+        </p>
+        <p
+          className="indent"
+        >
+          }),
+        </p>
+        <p>
+          ];
+        </p>
+      </div>
+      <p>
+        On the server, if an error in rendering the application occurs it will
+         redirect the request to 
+        <span
+          className="highlight"
+        >
+          /error
+        </span>
+        , 
+        <a
+          href="https://github.com/chichiwang/tamsui/blob/main/server/appHandler.tsx"
+          rel="noreferrer"
+          target="_blank"
+        >
+          configured by default
+        </a>
+         to be the 
+        <a
+          href="https://github.com/chichiwang/tamsui/blob/main/pages/ErrorPage"
+          rel="noreferrer"
+          target="_blank"
+        >
+          application's error page
+        </a>
+        .
+      </p>
+      <p>
+        On the client, an error in a page will render the 
+        <a
+          href="https://github.com/chichiwang/tamsui/blob/main/pages/ErrorPage"
+          rel="noreferrer"
+          target="_blank"
+        >
+          ErrorPage component
+        </a>
+         as fallback.
+      </p>
+      <p>
+        <b>
+          To change the path to the error page
+        </b>
+        : change the value of the constant 
+        <span
+          className="highlight"
+        >
+          errorPagePath
+        </span>
+         in 
+        <a
+          href="https://github.com/chichiwang/tamsui/blob/main/server/appHandler.tsx"
+          rel="noreferrer"
+          target="_blank"
+        >
+          server/appHandler.tsx
+        </a>
+        . Make sure you define this route in the 
+        <a
+          href="https://github.com/chichiwang/tamsui/blob/main/app/dataRoutes/index.ts"
+          rel="noreferrer"
+          target="_blank"
+        >
+          app/dataRoutes/index.ts
+        </a>
+         file.
+      </p>
+      <p>
+        Alternatively, keep the error page path and just replace the 
+        <a
+          href="https://github.com/chichiwang/tamsui/blob/main/pages/ErrorPage"
+          rel="noreferrer"
+          target="_blank"
+        >
+          ErrorPage component
+        </a>
+        .
+      </p>
     </article>
   </section>
 </div>

--- a/pages/Documentation/__tests__/__snapshots__/index.test.js.snap
+++ b/pages/Documentation/__tests__/__snapshots__/index.test.js.snap
@@ -2125,6 +2125,13 @@ exports[`Documentation Page Component matches snapshot 1`] = `
             Adding an Application Directory
           </a>
         </li>
+        <li>
+          <a
+            href="#Static-Files"
+          >
+            Static Files
+          </a>
+        </li>
       </ul>
     </article>
   </section>
@@ -2613,6 +2620,132 @@ exports[`Documentation Page Component matches snapshot 1`] = `
                array to ensure that the test runner knows which directories to cover.
             </li>
           </ul>
+        </li>
+      </ul>
+    </article>
+  </section>
+  <section
+    className="headingBlock"
+  >
+    <div
+      className="container"
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+    >
+      <div
+        className="wrapper"
+      >
+        <h3
+          className="tag"
+          id="Static-Files"
+        >
+          Static Files
+        </h3>
+        <a
+          aria-labelledby="Static-Files"
+          className="link"
+          href="#Static-Files"
+        >
+          <svg
+            height="1.75rem"
+            viewBox="0 0 24 24"
+            width="1.75rem"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g
+              fill="none"
+              stroke="currentColor"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2.5}
+            >
+              <path
+                d="M14 11.998C14 9.506 11.683 7 8.857 7H7.143C4.303 7 2 9.238 2 11.998c0 2.378 1.71 4.368 4 4.873a5.3 5.3 0 0 0 1.143.124"
+              />
+              <path
+                d="M10 11.998c0 2.491 2.317 4.997 5.143 4.997h1.714c2.84 0 5.143-2.237 5.143-4.997c0-2.379-1.71-4.37-4-4.874A5.3 5.3 0 0 0 16.857 7"
+              />
+            </g>
+          </svg>
+        </a>
+      </div>
+    </div>
+    <article>
+      <p>
+        The directory 
+        <a
+          href="https://github.com/chichiwang/tamsui/blob/main/static"
+          rel="noreferrer"
+          target="_blank"
+        >
+          static/
+        </a>
+        , housed in the project root, is copied directly into the 
+        <span
+          className="highlight"
+        >
+          dist/
+        </span>
+         directory on the project build. This directory is served statically by the
+         Express server.
+      </p>
+      <p>
+        This directory is meant to house static files (images, JSON files, etc.) used by 
+        <b>
+          Tamsui
+        </b>
+        . This is a stop-gap solution: the Express server should not be used to serve static
+         files like images - these should be housed in a CDN.
+      </p>
+      <p>
+        On deployment, the 
+        <span
+          className="highlight"
+        >
+          /dist/static/
+        </span>
+         directory can be uploaded to your CDN of choice.
+      </p>
+      <p>
+        <b>
+          TODO
+        </b>
+         (future tasks for the 
+        <b>
+          Tamsui
+        </b>
+         project):
+      </p>
+      <ul
+        className="list"
+      >
+        <li>
+          Add a configuration to provide a base route to static assets
+             (so a CDN route can be provided)
+        </li>
+        <li>
+          Add a configuration to enable/disable serving 
+          <span
+            className="highlight"
+          >
+            /static
+          </span>
+           directory files in various environments (development/production)
+        </li>
+        <li>
+          Add configuration options for serving built assets (
+          <span
+            className="highlight"
+          >
+            /scripts
+          </span>
+          , 
+          <span
+            className="highlight"
+          >
+            /styles
+          </span>
+          ) as well, so these assets can also be served via CDN
         </li>
       </ul>
     </article>

--- a/pages/Documentation/__tests__/__snapshots__/index.test.js.snap
+++ b/pages/Documentation/__tests__/__snapshots__/index.test.js.snap
@@ -2153,6 +2153,13 @@ exports[`Documentation Page Component matches snapshot 1`] = `
             Pull Request Template
           </a>
         </li>
+        <li>
+          <a
+            href="#Github-Workflow"
+          >
+            Github Workflow
+          </a>
+        </li>
       </ul>
     </article>
   </section>
@@ -3385,6 +3392,91 @@ exports[`Documentation Page Component matches snapshot 1`] = `
            or extending the codebase.
         </li>
       </ul>
+    </article>
+  </section>
+  <section
+    className="headingBlock"
+  >
+    <div
+      className="container"
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+    >
+      <div
+        className="wrapper"
+      >
+        <h3
+          className="tag"
+          id="Github-Workflow"
+        >
+          Github Workflow
+        </h3>
+        <a
+          aria-labelledby="Github-Workflow"
+          className="link"
+          href="#Github-Workflow"
+        >
+          <svg
+            height="1.75rem"
+            viewBox="0 0 24 24"
+            width="1.75rem"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g
+              fill="none"
+              stroke="currentColor"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2.5}
+            >
+              <path
+                d="M14 11.998C14 9.506 11.683 7 8.857 7H7.143C4.303 7 2 9.238 2 11.998c0 2.378 1.71 4.368 4 4.873a5.3 5.3 0 0 0 1.143.124"
+              />
+              <path
+                d="M10 11.998c0 2.491 2.317 4.997 5.143 4.997h1.714c2.84 0 5.143-2.237 5.143-4.997c0-2.379-1.71-4.37-4-4.874A5.3 5.3 0 0 0 16.857 7"
+              />
+            </g>
+          </svg>
+        </a>
+      </div>
+    </div>
+    <article>
+      <b>
+        Tamsui
+      </b>
+       contains a 
+      <a
+        href="https://docs.github.com/en/actions/using-workflows/about-workflows"
+        rel="noreferrer"
+        target="_blank"
+      >
+        Github workflow
+      </a>
+       configured to 
+      <a
+        href="https://github.com/chichiwang/tamsui/blob/main/.github/workflows/lint-test.yml"
+        rel="noreferrer"
+        target="_blank"
+      >
+        run the linter and test runner
+      </a>
+       on 
+      <a
+        href="https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#push"
+        rel="noreferrer"
+        target="_blank"
+      >
+        push events
+      </a>
+      . If this is not desired, 
+      <a
+        href="https://docs.github.com/en/actions/using-workflows/disabling-and-enabling-a-workflow#disabling-a-workflow"
+        rel="noreferrer"
+        target="_blank"
+      >
+        disable the workflow in Github
+      </a>
+      .
     </article>
   </section>
 </div>

--- a/pages/Documentation/__tests__/__snapshots__/index.test.js.snap
+++ b/pages/Documentation/__tests__/__snapshots__/index.test.js.snap
@@ -2146,6 +2146,13 @@ exports[`Documentation Page Component matches snapshot 1`] = `
             Testing
           </a>
         </li>
+        <li>
+          <a
+            href="#Pull-Request-Template"
+          >
+            Pull Request Template
+          </a>
+        </li>
       </ul>
     </article>
   </section>
@@ -3251,6 +3258,133 @@ exports[`Documentation Page Component matches snapshot 1`] = `
         </span>
          will also work.
       </p>
+    </article>
+  </section>
+  <section
+    className="headingBlock"
+  >
+    <div
+      className="container"
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+    >
+      <div
+        className="wrapper"
+      >
+        <h3
+          className="tag"
+          id="Pull-Request-Template"
+        >
+          Pull Request Template
+        </h3>
+        <a
+          aria-labelledby="Pull-Request-Template"
+          className="link"
+          href="#Pull-Request-Template"
+        >
+          <svg
+            height="1.75rem"
+            viewBox="0 0 24 24"
+            width="1.75rem"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g
+              fill="none"
+              stroke="currentColor"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2.5}
+            >
+              <path
+                d="M14 11.998C14 9.506 11.683 7 8.857 7H7.143C4.303 7 2 9.238 2 11.998c0 2.378 1.71 4.368 4 4.873a5.3 5.3 0 0 0 1.143.124"
+              />
+              <path
+                d="M10 11.998c0 2.491 2.317 4.997 5.143 4.997h1.714c2.84 0 5.143-2.237 5.143-4.997c0-2.379-1.71-4.37-4-4.874A5.3 5.3 0 0 0 16.857 7"
+              />
+            </g>
+          </svg>
+        </a>
+      </div>
+    </div>
+    <article>
+      <p>
+        <b>
+          Tamsui
+        </b>
+         contains a 
+        <a
+          href="https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository"
+          rel="noreferrer"
+          target="_blank"
+        >
+          Github Pull Request template
+        </a>
+         that is intended to provide a scaffold for a thorough pull request. 
+        <a
+          href="https://github.com/chichiwang/tamsui/blob/main/.github/pull_request_template.md"
+          rel="noreferrer"
+          target="_blank"
+        >
+          This template
+        </a>
+         provides the following sections:
+      </p>
+      <ul
+        className="list"
+      >
+        <li>
+          <span
+            className="highlight"
+          >
+            Description
+          </span>
+          :
+          <ul
+            className="list"
+          >
+            <li>
+              Link to a related issue/story - important for documentation of
+               why this change is being made
+            </li>
+            <li>
+              A prompt to provide a description of the intent of the changes
+            </li>
+          </ul>
+        </li>
+        <li>
+          <span
+            className="highlight"
+          >
+            Changes
+          </span>
+          : A prompt to list the code changes in the pull request
+        </li>
+        <li>
+          <span
+            className="highlight"
+          >
+            Steps to QA
+          </span>
+          : A prompt to provide steps for reviewers to verify the changes
+           achieve their intended result
+        </li>
+      </ul>
+      <p>
+        The reason for these sections is two-fold:
+      </p>
+      <ul
+        className="list numbered"
+      >
+        <li>
+          Make it easier for reviewers to review the code changes, with full context of the reasons
+           the changes are being made, in order that the team can produce the best results for the codebase.
+        </li>
+        <li>
+          Provide a history of documentation in the repository, so that every significant change is
+           documented and vetted. This can be useful in the future to trace changes and intent when debugging
+           or extending the codebase.
+        </li>
+      </ul>
     </article>
   </section>
 </div>

--- a/pages/Documentation/index.tsx
+++ b/pages/Documentation/index.tsx
@@ -11,6 +11,7 @@ import RunningTheApplication from './RunningTheApplication';
 import ProjectDirectories from './ProjectDirectories';
 import AddingAnApplicationDirectory from './AddingAnApplicationDirectory';
 import StaticFiles from './StaticFiles';
+import ErrorBoundary from './ErrorBoundary';
 
 import styles from './styles.module.scss';
 
@@ -58,6 +59,9 @@ function Documentation() {
           <li>
             <a href="#Static-Files">Static Files</a>
           </li>
+          <li>
+            <a href="#Error-Boundary">Error Boundary</a>
+          </li>
         </ul>
       </HeadingBlock>
 
@@ -65,6 +69,7 @@ function Documentation() {
       <ProjectDirectories />
       <AddingAnApplicationDirectory />
       <StaticFiles />
+      <ErrorBoundary />
     </ContentBlock>
   );
 }

--- a/pages/Documentation/index.tsx
+++ b/pages/Documentation/index.tsx
@@ -12,6 +12,7 @@ import ProjectDirectories from './ProjectDirectories';
 import AddingAnApplicationDirectory from './AddingAnApplicationDirectory';
 import StaticFiles from './StaticFiles';
 import ErrorBoundary from './ErrorBoundary';
+import Testing from './Testing';
 
 import styles from './styles.module.scss';
 
@@ -62,6 +63,9 @@ function Documentation() {
           <li>
             <a href="#Error-Boundary">Error Boundary</a>
           </li>
+          <li>
+            <a href="#Testing">Testing</a>
+          </li>
         </ul>
       </HeadingBlock>
 
@@ -70,6 +74,7 @@ function Documentation() {
       <AddingAnApplicationDirectory />
       <StaticFiles />
       <ErrorBoundary />
+      <Testing />
     </ContentBlock>
   );
 }

--- a/pages/Documentation/index.tsx
+++ b/pages/Documentation/index.tsx
@@ -10,6 +10,7 @@ import NPMScripts from './NPMScripts';
 import RunningTheApplication from './RunningTheApplication';
 import ProjectDirectories from './ProjectDirectories';
 import AddingAnApplicationDirectory from './AddingAnApplicationDirectory';
+import StaticFiles from './StaticFiles';
 
 import styles from './styles.module.scss';
 
@@ -54,12 +55,16 @@ function Documentation() {
           <li>
             <a href="#Adding-an-Application-Directory">Adding an Application Directory</a>
           </li>
+          <li>
+            <a href="#Static-Files">Static Files</a>
+          </li>
         </ul>
       </HeadingBlock>
 
       <RunningTheApplication />
       <ProjectDirectories />
       <AddingAnApplicationDirectory />
+      <StaticFiles />
     </ContentBlock>
   );
 }

--- a/pages/Documentation/index.tsx
+++ b/pages/Documentation/index.tsx
@@ -14,6 +14,7 @@ import StaticFiles from './StaticFiles';
 import ErrorBoundary from './ErrorBoundary';
 import Testing from './Testing';
 import PullRequestTemplate from './PullRequestTemplate';
+import GithubWorkflow from './GithubWorkflow';
 
 import styles from './styles.module.scss';
 
@@ -70,6 +71,9 @@ function Documentation() {
           <li>
             <a href="#Pull-Request-Template">Pull Request Template</a>
           </li>
+          <li>
+            <a href="#Github-Workflow">Github Workflow</a>
+          </li>
         </ul>
       </HeadingBlock>
 
@@ -80,6 +84,7 @@ function Documentation() {
       <ErrorBoundary />
       <Testing />
       <PullRequestTemplate />
+      <GithubWorkflow />
     </ContentBlock>
   );
 }

--- a/pages/Documentation/index.tsx
+++ b/pages/Documentation/index.tsx
@@ -13,6 +13,7 @@ import AddingAnApplicationDirectory from './AddingAnApplicationDirectory';
 import StaticFiles from './StaticFiles';
 import ErrorBoundary from './ErrorBoundary';
 import Testing from './Testing';
+import PullRequestTemplate from './PullRequestTemplate';
 
 import styles from './styles.module.scss';
 
@@ -66,6 +67,9 @@ function Documentation() {
           <li>
             <a href="#Testing">Testing</a>
           </li>
+          <li>
+            <a href="#Pull-Request-Template">Pull Request Template</a>
+          </li>
         </ul>
       </HeadingBlock>
 
@@ -75,6 +79,7 @@ function Documentation() {
       <StaticFiles />
       <ErrorBoundary />
       <Testing />
+      <PullRequestTemplate />
     </ContentBlock>
   );
 }

--- a/pages/Documentation/styles.module.scss
+++ b/pages/Documentation/styles.module.scss
@@ -6,6 +6,10 @@ $indent-unit: map.get(var.$content, 'padding');
 .indent {
   margin-left: $indent-unit;
 
+  &.twice {
+    margin-left: calc($indent-unit * 2);
+  }
+
   &.checklist {
     margin-left: calc($indent-unit * 1.5);
   }
@@ -107,20 +111,33 @@ $indent-unit: map.get(var.$content, 'padding');
   }
 
   p {
-    margin: 0;
+    margin-top: 0;
+    margin-bottom: 0;
     color: map.get(var.$colors, 'white');
-  }
-
-  .red {
-    color: map.get(var.$code-colors, 'red');
-  }
-
-  .orange {
-    color: map.get(var.$colors, 'orange');
   }
 
   .blue {
     color: map.get(var.$code-colors, 'blue');
+  }
+
+  .darkBlue {
+    color: map.get(var.$code-colors, 'darkBlue');
+  }
+
+  .grey {
+    color: map.get(var.$code-colors, 'grey');
+  }
+
+  .orange {
+    color: map.get(var.$code-colors, 'orange');
+  }
+
+  .purple {
+    color: map.get(var.$code-colors, 'purple');
+  }
+
+  .red {
+    color: map.get(var.$code-colors, 'red');
   }
 
   @media screen and (max-width: var.$breakpoint-small-max) {

--- a/pages/Documentation/styles.module.scss
+++ b/pages/Documentation/styles.module.scss
@@ -29,6 +29,10 @@ $indent-unit: map.get(var.$content, 'padding');
     list-style: none;
   }
 
+  &.numbered {
+    list-style-type: decimal;
+  }
+
   & li {
     margin: calc(map.get(var.$content, 'padding') * 0.75) 0;
   }


### PR DESCRIPTION
## Description
Linked to Issue: #65 
Add sections to the page `/documentation`:
* Static Files
* Error Boundary
* Testing
* Pull Request Template
* Github Workflow

Additionally, make grammatical fixes and update code snippets for sections in `docs/README.md`:
* Static Files
* Error Boundary
* Testing

## Changes
* Add new colors to `$code-colors` map in `app/var.module.scss`:
  * `darkBlue`
  * `grey`
  * `purple`
* Grammatical fixes to sections in `docs/README.md`
  * Static Files
  * Error Boundary
  * Testing
* Code snippet update in `docs/README.md` in section "Error Boundary"
  * Change the order of import statements
* Create component `pages/Documentation/ErrorBoundary.tsx`
* Create component `pages/Documentation/GithubWorkflow.tsx`
* Create component `pages/Documentation/PullRequestTemplate.tsx`
* Create component `pages/Documentation/StaticFiles.tsx`
* Create component `pages/Documentation/Testing.tsx`
* Add sections to `pages/Documentation/index.tsx`
  * Static Files
  * Error Boundary
  * Testing
  * Pull Request Template
  * Github Workflow

## Steps to QA
* Verify the changes to `docs/README.md` look correct
* Pull down and switch to this branch
* Verify in browser on the `/documentation` page:
  * New content looks correct
  * Links are correct
  * Copying from the code block in section "Error Boundary" copies the code to system clipboard
  * Print styles (print preview) looks correct
