### PR TITLE
Add section to Documentation page: Building for Production

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -141,6 +141,6 @@ The reason for these sections is two-fold:
 **Tamsui** contains a [Github workflow](https://docs.github.com/en/actions/using-workflows/about-workflows) configured to [run the linter and test runner](../.github/workflows/lint-test.yml) on [push events](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#push). If this is not desired, [disable the workflow in Github](https://docs.github.com/en/actions/using-workflows/disabling-and-enabling-a-workflow#disabling-a-workflow).
 
 ## Building for Production
-To build for production run `npm build:prod`. The production assets to be deployed live in the `dist/` directory.
+To build for production run `npm build:prod`. The production assets to be deployed will be generated in the `dist/` directory.
 
 To build the production assets and run the Express server in a single command, run `npm start`.

--- a/pages/Documentation/__tests__/__snapshots__/index.test.js.snap
+++ b/pages/Documentation/__tests__/__snapshots__/index.test.js.snap
@@ -83,6 +83,13 @@ exports[`Documentation Page Component matches snapshot 1`] = `
             Developing Locally
           </a>
         </li>
+        <li>
+          <a
+            href="#Building-for-Production"
+          >
+            Building for Production
+          </a>
+        </li>
       </ul>
     </article>
   </section>
@@ -3477,6 +3484,80 @@ exports[`Documentation Page Component matches snapshot 1`] = `
         disable the workflow in Github
       </a>
       .
+    </article>
+  </section>
+  <section
+    className="headingBlock"
+  >
+    <div
+      className="container"
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+    >
+      <div
+        className="wrapper"
+      >
+        <h2
+          className="tag"
+          id="Building-for-Production"
+        >
+          Building for Production
+        </h2>
+        <a
+          aria-labelledby="Building-for-Production"
+          className="link"
+          href="#Building-for-Production"
+        >
+          <svg
+            height="1.75rem"
+            viewBox="0 0 24 24"
+            width="1.75rem"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g
+              fill="none"
+              stroke="currentColor"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2.5}
+            >
+              <path
+                d="M14 11.998C14 9.506 11.683 7 8.857 7H7.143C4.303 7 2 9.238 2 11.998c0 2.378 1.71 4.368 4 4.873a5.3 5.3 0 0 0 1.143.124"
+              />
+              <path
+                d="M10 11.998c0 2.491 2.317 4.997 5.143 4.997h1.714c2.84 0 5.143-2.237 5.143-4.997c0-2.379-1.71-4.37-4-4.874A5.3 5.3 0 0 0 16.857 7"
+              />
+            </g>
+          </svg>
+        </a>
+      </div>
+    </div>
+    <article>
+      <p>
+        To build for production run 
+        <span
+          className="highlight"
+        >
+          npm build:prod
+        </span>
+        . The production assets to be deployed will be generated in the 
+        <span
+          className="highlight"
+        >
+          dist/
+        </span>
+         directory.
+      </p>
+      <p>
+        To build the production assets and run the Express server in a single
+           command, run 
+        <span
+          className="highlight"
+        >
+          npm start
+        </span>
+        .
+      </p>
     </article>
   </section>
 </div>

--- a/pages/Documentation/index.tsx
+++ b/pages/Documentation/index.tsx
@@ -21,7 +21,10 @@ import styles from './styles.module.scss';
 function Documentation() {
   return (
     <ContentBlock>
-      <HeadingBlock level="1" heading="Developer Documentation">
+      <HeadingBlock
+        level="1"
+        heading="Developer Documentation"
+      >
         <p>
           {'Documentation is also provided in the '}
           <ExternalLink href="https://github.com/chichiwang/tamsui">Github repository</ExternalLink>
@@ -31,7 +34,10 @@ function Documentation() {
         </p>
       </HeadingBlock>
 
-      <HeadingBlock level="2" heading="Contents">
+      <HeadingBlock
+        level="2"
+        heading="Contents"
+      >
         <ul className={classNames(styles.list, styles.content)}>
           <li>
             <a href="#Starting-a-Project">Starting a Project</a>
@@ -42,13 +48,20 @@ function Documentation() {
           <li>
             <a href="#Developing-Locally">Developing Locally</a>
           </li>
+          <li>
+            <a href="#Building-for-Production">Building for Production</a>
+          </li>
         </ul>
       </HeadingBlock>
 
       <StartingAProject />
       <NPMScripts />
 
-      <HeadingBlock level="2" id="Developing-Locally" heading="Developing Locally">
+      <HeadingBlock
+        level="2"
+        id="Developing-Locally"
+        heading="Developing Locally"
+      >
         <ul className={classNames(styles.list, styles.content)}>
           <li>
             <a href="#Running-the-Application">Running the Application</a>
@@ -85,6 +98,27 @@ function Documentation() {
       <Testing />
       <PullRequestTemplate />
       <GithubWorkflow />
+
+      <HeadingBlock
+        level="2"
+        id="Building-for-Production"
+        heading="Building for Production"
+      >
+        <p>
+          {'To build for production run '}
+          <span className={styles.highlight}>npm build:prod</span>
+          {'. The production assets to be deployed will be generated in the '}
+          <span className={styles.highlight}>dist/</span>
+          {' directory.'}
+        </p>
+
+        <p>
+          {`To build the production assets and run the Express server in a single
+           command, run `}
+          <span className={styles.highlight}>npm start</span>
+          .
+        </p>
+      </HeadingBlock>
     </ContentBlock>
   );
 }


### PR DESCRIPTION
## Description
Linked to Issue: #65 
Add section "Building for Production" to `/documentation` page. Minor grammatical fix to section "Building for Production" in `docs/README.md`

## Changes
* Grammatical fix to section "Building for Production" in `docs/README.md`
* Add section "Building for Production" in `pages/Documentation/index.tsx`

## Steps to QA
* Verify the updates in `docs/README.md` look good and read well
* Pull down and switch to this branch
* Run the app and verify in browser on the `/documentation` page
  * Link to section "Building for Production" works
  * Print preview looks correct