### PR TITLE
Add prop to `CopyButton` component: `colorMode`

### DIFF
--- a/app/components/CopyButton/__tests__/__snapshots__/index.test.js.snap
+++ b/app/components/CopyButton/__tests__/__snapshots__/index.test.js.snap
@@ -2,10 +2,184 @@
 
 exports[`CopyButton component matches the className snapshot 1`] = `
 <div
-  className="copyPosition center"
+  className="copyContainer center"
 >
   <div
-    className="copyContainer"
+    className="copyWrapper"
+  >
+    <div
+      className="message"
+    >
+      <div
+        className="successMessage"
+      >
+        <span>
+          Copied!
+        </span>
+      </div>
+      <div
+        className="errorMessage"
+      >
+        <span>
+          Failed!
+        </span>
+      </div>
+    </div>
+    <button
+      aria-label="Copy text"
+      className="copyButton"
+      onClick={[Function]}
+      type="button"
+    >
+      <svg
+        className="copyIcon"
+        height="1em"
+        viewBox="0 0 24 24"
+        width="1em"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <g
+          fill="none"
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+        >
+          <path
+            d="M7 9.667A2.667 2.667 0 0 1 9.667 7h8.666A2.667 2.667 0 0 1 21 9.667v8.666A2.667 2.667 0 0 1 18.333 21H9.667A2.667 2.667 0 0 1 7 18.333z"
+          />
+          <path
+            d="M4.012 16.737A2 2 0 0 1 3 15V5c0-1.1.9-2 2-2h10c.75 0 1.158.385 1.5 1"
+          />
+        </g>
+      </svg>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`CopyButton component matches the dark-mode snapshot 1`] = `
+<div
+  className="copyContainer center"
+>
+  <div
+    className="copyWrapper"
+  >
+    <div
+      className="message"
+    >
+      <div
+        className="successMessage"
+      >
+        <span>
+          Copied!
+        </span>
+      </div>
+      <div
+        className="errorMessage"
+      >
+        <span>
+          Failed!
+        </span>
+      </div>
+    </div>
+    <button
+      aria-label="Copy text"
+      className="copyButton"
+      onClick={[Function]}
+      type="button"
+    >
+      <svg
+        className="copyIcon"
+        height="1em"
+        viewBox="0 0 24 24"
+        width="1em"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <g
+          fill="none"
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+        >
+          <path
+            d="M7 9.667A2.667 2.667 0 0 1 9.667 7h8.666A2.667 2.667 0 0 1 21 9.667v8.666A2.667 2.667 0 0 1 18.333 21H9.667A2.667 2.667 0 0 1 7 18.333z"
+          />
+          <path
+            d="M4.012 16.737A2 2 0 0 1 3 15V5c0-1.1.9-2 2-2h10c.75 0 1.158.385 1.5 1"
+          />
+        </g>
+      </svg>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`CopyButton component matches the default-mode snapshot 1`] = `
+<div
+  className="copyContainer center"
+>
+  <div
+    className="copyWrapper"
+  >
+    <div
+      className="message"
+    >
+      <div
+        className="successMessage"
+      >
+        <span>
+          Copied!
+        </span>
+      </div>
+      <div
+        className="errorMessage"
+      >
+        <span>
+          Failed!
+        </span>
+      </div>
+    </div>
+    <button
+      aria-label="Copy text"
+      className="copyButton"
+      onClick={[Function]}
+      type="button"
+    >
+      <svg
+        className="copyIcon"
+        height="1em"
+        viewBox="0 0 24 24"
+        width="1em"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <g
+          fill="none"
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+        >
+          <path
+            d="M7 9.667A2.667 2.667 0 0 1 9.667 7h8.666A2.667 2.667 0 0 1 21 9.667v8.666A2.667 2.667 0 0 1 18.333 21H9.667A2.667 2.667 0 0 1 7 18.333z"
+          />
+          <path
+            d="M4.012 16.737A2 2 0 0 1 3 15V5c0-1.1.9-2 2-2h10c.75 0 1.158.385 1.5 1"
+          />
+        </g>
+      </svg>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`CopyButton component matches the light-mode snapshot 1`] = `
+<div
+  className="copyContainer center"
+>
+  <div
+    className="copyWrapper lightMode"
   >
     <div
       className="message"
@@ -60,10 +234,10 @@ exports[`CopyButton component matches the className snapshot 1`] = `
 
 exports[`CopyButton component matches the snapshot 1`] = `
 <div
-  className="copyPosition"
+  className="copyContainer"
 >
   <div
-    className="copyContainer"
+    className="copyWrapper"
   >
     <div
       className="message"

--- a/app/components/CopyButton/__tests__/index.test.js
+++ b/app/components/CopyButton/__tests__/index.test.js
@@ -10,7 +10,7 @@ import {
 } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
-import CopyButton from '../index';
+import CopyButton, { ColorModes } from '../index';
 
 jest.useFakeTimers();
 
@@ -46,6 +46,30 @@ describe('CopyButton component', () => {
   test('matches the className snapshot', () => {
     const tree = renderer.create(
       <CopyButton className="center" textToCopy="Business Address" />,
+    ).toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('matches the dark-mode snapshot', () => {
+    const tree = renderer.create(
+      <CopyButton className="center" colorMode={ColorModes.dark} textToCopy="s3cr37 m3554g3" />,
+    ).toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('matches the default-mode snapshot', () => {
+    const tree = renderer.create(
+      <CopyButton className="center" colorMode={ColorModes.default} textToCopy="Santa's List" />,
+    ).toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('matches the light-mode snapshot', () => {
+    const tree = renderer.create(
+      <CopyButton className="center" colorMode={ColorModes.light} textToCopy="Homework" />,
     ).toJSON();
 
     expect(tree).toMatchSnapshot();

--- a/app/components/CopyButton/index.tsx
+++ b/app/components/CopyButton/index.tsx
@@ -5,17 +5,24 @@ import CopyIcon from 'app/components/CopyIcon';
 
 import styles from './styles.module.scss';
 
-type CopyButtonProps = {
-  className?: string;
-  textToCopy: string;
-};
-
 enum CopyStates {
   ready,
   copying,
   copied,
   errored
 }
+
+export enum ColorModes {
+  dark = 'dark',
+  default = 'dark',
+  light = 'light',
+}
+
+type CopyButtonProps = {
+  className?: string;
+  colorMode?: ColorModes,
+  textToCopy: string;
+};
 
 const ButtonContent = {
   [CopyStates.ready]: (<CopyIcon className={styles.copyIcon} />),
@@ -28,6 +35,7 @@ const messageDisplayTime = 2000;
 
 function CopyButton({
   className,
+  colorMode = ColorModes.default,
   textToCopy,
 }: CopyButtonProps) {
   const [copyState, setCopyState] = useState(CopyStates.ready);
@@ -55,8 +63,9 @@ function CopyButton({
       });
   }
 
-  const containerClassname = classNames({
-    [styles.copyContainer]: true,
+  const wrapperClassName = classNames({
+    [styles.copyWrapper]: true,
+    [styles.lightMode]: colorMode === ColorModes.light,
     [styles.disabled]: copyState === CopyStates.copying,
     [styles.copied]: copyState === CopyStates.copied,
     [styles.error]: copyState === CopyStates.errored,
@@ -71,8 +80,8 @@ function CopyButton({
   };
 
   return (
-    <div className={classNames(styles.copyPosition, className)}>
-      <div className={containerClassname}>
+    <div className={classNames(styles.copyContainer, className)}>
+      <div className={wrapperClassName}>
         <div className={styles.message}>
           <div className={styles.successMessage}>
             <span>Copied!</span>

--- a/app/components/CopyButton/styles.module.scss
+++ b/app/components/CopyButton/styles.module.scss
@@ -6,12 +6,12 @@ $padding-unit: map.get(var.$content, 'padding');
 $button-size: 1.75rem;
 $icon-size: 1.125rem;
 
-.copyPosition {
+.copyContainer {
   position: relative;
   width: $button-size;
   height: $button-size;
 
-  .copyContainer {
+  .copyWrapper {
     position: absolute;
     display: flex;
     top: 0;
@@ -87,6 +87,14 @@ $icon-size: 1.125rem;
         .copyIcon {
           color: map.get(var.$colors, 'white');
         }
+      }
+    }
+
+    &.lightMode .copyButton {
+      border: 1px solid map.get(var.$colors, 'white');
+
+      .copyIcon {
+        color: map.get(var.$colors, 'white');
       }
     }
 

--- a/pages/Documentation/AddingAnApplicationDirectory.tsx
+++ b/pages/Documentation/AddingAnApplicationDirectory.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import HeadingBlock from 'app/components/HeadingBlock';
 import ExternalLink from 'app/components/ExternalLink';
-import CopyButton from 'app/components/CopyButton';
+import CopyButton, { ColorModes } from 'app/components/CopyButton';
 
 import styles from './styles.module.scss';
 
@@ -35,6 +35,7 @@ function AddingAnApplicationDirectory() {
         <CopyButton
           className={styles.copyButton}
           textToCopy={'import Module from app/Module;\nimport PageModule from page/PageModule;'}
+          colorMode={ColorModes.light}
         />
         <p>
           <span className={styles.red}>import</span>

--- a/pages/Documentation/ErrorBoundary.tsx
+++ b/pages/Documentation/ErrorBoundary.tsx
@@ -3,7 +3,7 @@ import classNames from 'classnames';
 
 import HeadingBlock from 'app/components/HeadingBlock';
 import ExternalLink from 'app/components/ExternalLink';
-import CopyButton from 'app/components/CopyButton';
+import CopyButton, { ColorModes } from 'app/components/CopyButton';
 
 import styles from './styles.module.scss';
 
@@ -54,7 +54,11 @@ function ErrorBoundary() {
       </p>
 
       <div className={styles.codeBlock}>
-        <CopyButton className={styles.copyButton} textToCopy={errorBoundarySnippet} />
+        <CopyButton
+          className={styles.copyButton}
+          textToCopy={errorBoundarySnippet}
+          colorMode={ColorModes.light}
+        />
         <p>
           <span className={styles.grey}>&#47;&#47; app/dataRoutes/index.ts</span>
         </p>

--- a/pages/Documentation/__tests__/__snapshots__/index.test.js.snap
+++ b/pages/Documentation/__tests__/__snapshots__/index.test.js.snap
@@ -788,10 +788,10 @@ exports[`Documentation Page Component matches snapshot 1`] = `
                   analyze
                 </span>
                 <div
-                  className="copyPosition copyButton"
+                  className="copyContainer copyButton"
                 >
                   <div
-                    className="copyContainer"
+                    className="copyWrapper"
                   >
                     <div
                       className="message"
@@ -875,10 +875,10 @@ exports[`Documentation Page Component matches snapshot 1`] = `
                   analyze:dev
                 </span>
                 <div
-                  className="copyPosition copyButton"
+                  className="copyContainer copyButton"
                 >
                   <div
-                    className="copyContainer"
+                    className="copyWrapper"
                   >
                     <div
                       className="message"
@@ -956,10 +956,10 @@ exports[`Documentation Page Component matches snapshot 1`] = `
                   analyze:prod
                 </span>
                 <div
-                  className="copyPosition copyButton"
+                  className="copyContainer copyButton"
                 >
                   <div
-                    className="copyContainer"
+                    className="copyWrapper"
                   >
                     <div
                       className="message"
@@ -1037,10 +1037,10 @@ exports[`Documentation Page Component matches snapshot 1`] = `
                   build:dev
                 </span>
                 <div
-                  className="copyPosition copyButton"
+                  className="copyContainer copyButton"
                 >
                   <div
-                    className="copyContainer"
+                    className="copyWrapper"
                   >
                     <div
                       className="message"
@@ -1115,10 +1115,10 @@ exports[`Documentation Page Component matches snapshot 1`] = `
                   build:dist
                 </span>
                 <div
-                  className="copyPosition copyButton"
+                  className="copyContainer copyButton"
                 >
                   <div
-                    className="copyContainer"
+                    className="copyWrapper"
                   >
                     <div
                       className="message"
@@ -1194,10 +1194,10 @@ exports[`Documentation Page Component matches snapshot 1`] = `
                   build:prod
                 </span>
                 <div
-                  className="copyPosition copyButton"
+                  className="copyContainer copyButton"
                 >
                   <div
-                    className="copyContainer"
+                    className="copyWrapper"
                   >
                     <div
                       className="message"
@@ -1272,10 +1272,10 @@ exports[`Documentation Page Component matches snapshot 1`] = `
                   build:static
                 </span>
                 <div
-                  className="copyPosition copyButton"
+                  className="copyContainer copyButton"
                 >
                   <div
-                    className="copyContainer"
+                    className="copyWrapper"
                   >
                     <div
                       className="message"
@@ -1356,10 +1356,10 @@ exports[`Documentation Page Component matches snapshot 1`] = `
                   clean
                 </span>
                 <div
-                  className="copyPosition copyButton"
+                  className="copyContainer copyButton"
                 >
                   <div
-                    className="copyContainer"
+                    className="copyWrapper"
                   >
                     <div
                       className="message"
@@ -1441,10 +1441,10 @@ exports[`Documentation Page Component matches snapshot 1`] = `
                   dev
                 </span>
                 <div
-                  className="copyPosition copyButton"
+                  className="copyContainer copyButton"
                 >
                   <div
-                    className="copyContainer"
+                    className="copyWrapper"
                   >
                     <div
                       className="message"
@@ -1522,10 +1522,10 @@ exports[`Documentation Page Component matches snapshot 1`] = `
                   lint
                 </span>
                 <div
-                  className="copyPosition copyButton"
+                  className="copyContainer copyButton"
                 >
                   <div
-                    className="copyContainer"
+                    className="copyWrapper"
                   >
                     <div
                       className="message"
@@ -1602,10 +1602,10 @@ exports[`Documentation Page Component matches snapshot 1`] = `
                   prod
                 </span>
                 <div
-                  className="copyPosition copyButton"
+                  className="copyContainer copyButton"
                 >
                   <div
-                    className="copyContainer"
+                    className="copyWrapper"
                   >
                     <div
                       className="message"
@@ -1683,10 +1683,10 @@ exports[`Documentation Page Component matches snapshot 1`] = `
                   run
                 </span>
                 <div
-                  className="copyPosition copyButton"
+                  className="copyContainer copyButton"
                 >
                   <div
-                    className="copyContainer"
+                    className="copyWrapper"
                   >
                     <div
                       className="message"
@@ -1761,10 +1761,10 @@ exports[`Documentation Page Component matches snapshot 1`] = `
                   start
                 </span>
                 <div
-                  className="copyPosition copyButton"
+                  className="copyContainer copyButton"
                 >
                   <div
-                    className="copyContainer"
+                    className="copyWrapper"
                   >
                     <div
                       className="message"
@@ -1835,10 +1835,10 @@ exports[`Documentation Page Component matches snapshot 1`] = `
                   test
                 </span>
                 <div
-                  className="copyPosition copyButton"
+                  className="copyContainer copyButton"
                 >
                   <div
-                    className="copyContainer"
+                    className="copyWrapper"
                   >
                     <div
                       className="message"
@@ -1909,10 +1909,10 @@ exports[`Documentation Page Component matches snapshot 1`] = `
                   test:snapshot
                 </span>
                 <div
-                  className="copyPosition copyButton"
+                  className="copyContainer copyButton"
                 >
                   <div
-                    className="copyContainer"
+                    className="copyWrapper"
                   >
                     <div
                       className="message"
@@ -1995,10 +1995,10 @@ exports[`Documentation Page Component matches snapshot 1`] = `
                   watch
                 </span>
                 <div
-                  className="copyPosition copyButton"
+                  className="copyContainer copyButton"
                 >
                   <div
-                    className="copyContainer"
+                    className="copyWrapper"
                   >
                     <div
                       className="message"
@@ -2476,10 +2476,10 @@ exports[`Documentation Page Component matches snapshot 1`] = `
         className="codeBlock"
       >
         <div
-          className="copyPosition copyButton"
+          className="copyContainer copyButton"
         >
           <div
-            className="copyContainer"
+            className="copyWrapper lightMode"
           >
             <div
               className="message"
@@ -2888,10 +2888,10 @@ exports[`Documentation Page Component matches snapshot 1`] = `
         className="codeBlock"
       >
         <div
-          className="copyPosition copyButton"
+          className="copyContainer copyButton"
         >
           <div
-            className="copyContainer"
+            className="copyWrapper lightMode"
           >
             <div
               className="message"


### PR DESCRIPTION
## Description
Linked to Issue: #65
The copy button is difficult to see on the dark background of the code blocks on the `/documentation` page. To remedy this, a `colorMode` prop is added to the `CopyButton` component, which defaults to "dark" but can be set to "light". An enum `ColorModes` is exported from the `CopyButton` component which allows consumers to set the color mode to either "dark", "default", or "light".

The "dark" and "default" color modes use the same blue as it always has. The new "light" color mode will set the default color of the SVG and outline of the button to white.

The copy buttons on the `/documentation` page that live in the code blocks have been updated to use the light color mode.

## Changes
* `app/components/CopyButton/index.tsx` updated:
  * export an enum `ColorModes` to allow consumers to choose the color mode for the button
  * a new prop `colorMode` accepts a `ColorModes` value to style the button colors
* `pages/Documentation/AddingAnApplicationDirectory.tsx` updated to render the `CopyButton` with a `colorMode` set to `ColorModes.light`
* `pages/Documentation/ErrorBoundary.tsx` updated to render the `CopyButton` with a `colorMode` set to `ColorModes.light`

## Steps to QA
* Pull down and switch to this branch
* Run the app and verify in browser:
  * The copy buttons in the section "NPM Scripts" section look the same as before (rendered in blue)
  * The copy buttons in the sections "Adding an Application Directory" and "Error Boundary" are rendered in white
    * The hover state of the copy button is unchanged