### PR TITLE
Fixes on Documentation page: Add spaces to code block

### DIFF
--- a/app/App/__tests__/__snapshots__/index.test.js.snap
+++ b/app/App/__tests__/__snapshots__/index.test.js.snap
@@ -5,6 +5,9 @@ exports[`App Component matches child snapshot 1`] = `
   lang="en"
 >
   <head>
+    <meta
+      charSet="utf-8"
+    />
     <title>
       Tamsui
     </title>
@@ -52,6 +55,9 @@ exports[`App Component matches no-child snapshot 1`] = `
   lang="en"
 >
   <head>
+    <meta
+      charSet="utf-8"
+    />
     <title>
       Tamsui
     </title>

--- a/app/App/index.tsx
+++ b/app/App/index.tsx
@@ -12,6 +12,7 @@ export default function App({ manifest, children }: AppProps): React.ReactElemen
     <React.StrictMode>
       <html lang="en">
         <head>
+          <meta charSet="utf-8" />
           <title>Tamsui</title>
           <link rel="stylesheet" type="text/css" href={`/${manifest['app.css']}`} />
           <link rel="apple-touch-icon" sizes="180x180" href="/static/images/favicon/apple-touch-icon.png" />

--- a/pages/Documentation/AddingAnApplicationDirectory.tsx
+++ b/pages/Documentation/AddingAnApplicationDirectory.tsx
@@ -44,8 +44,7 @@ function AddingAnApplicationDirectory() {
           {' '}
           <span className={styles.blue}>&apos;app/module&apos;</span>
           ;
-        </p>
-        <p>
+          <br />
           <span className={styles.red}>import</span>
           {' PageModule '}
           <span className={styles.red}>from</span>

--- a/pages/Documentation/ErrorBoundary.tsx
+++ b/pages/Documentation/ErrorBoundary.tsx
@@ -88,24 +88,27 @@ function ErrorBoundary() {
           <span className={styles.blue}>=</span>
           {' ['}
         </p>
-        <p className={styles.indent}>
+        <p>
+          &nbsp;&nbsp;
           <span className={styles.purple}>withErrorBoundary</span>
           (&#123;
         </p>
-        <p className={classNames(styles.indent, styles.twice)}>
+        <p>
+          &nbsp;&nbsp;&nbsp;&nbsp;
           <span className={styles.darkBlue}>path</span>
           {': '}
           <span className={styles.blue}>&apos;/path-to-page&apos;</span>
           ,
         </p>
-        <p className={classNames(styles.indent, styles.twice)}>
+        <p>
+          &nbsp;&nbsp;&nbsp;&nbsp;
           <span className={styles.darkBlue}>Component</span>
           {': '}
           <span className={styles.orange}>PageComponent</span>
           ,
         </p>
-        <p className={styles.indent}>
-          &#125;),
+        <p>
+          &nbsp;&nbsp;&#125;),
         </p>
         <p>
           ];

--- a/pages/Documentation/ErrorBoundary.tsx
+++ b/pages/Documentation/ErrorBoundary.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import classNames from 'classnames';
 
 import HeadingBlock from 'app/components/HeadingBlock';
 import ExternalLink from 'app/components/ExternalLink';

--- a/pages/Documentation/ErrorBoundary.tsx
+++ b/pages/Documentation/ErrorBoundary.tsx
@@ -60,8 +60,7 @@ function ErrorBoundary() {
         />
         <p>
           <span className={styles.grey}>&#47;&#47; app/dataRoutes/index.ts</span>
-        </p>
-        <p>
+          <br />
           <span className={styles.red}>import</span>
           {' '}
           <span className={styles.orange}>PageComponent</span>
@@ -70,46 +69,39 @@ function ErrorBoundary() {
           {' '}
           <span className={styles.blue}>&apos;pages/PageComponent&apos;</span>
           ;
-        </p>
-        <br />
-        <p>
+          <br />
+          <br />
           <span className={styles.red}>import</span>
           {' withErrorBoundary '}
           <span className={styles.red}>from</span>
           {' '}
           <span className={styles.blue}>&apos;./withErrorBoundary&apos;</span>
           ;
-        </p>
-        <br />
-        <p>
+          <br />
+          <br />
           <span className={styles.red}>const</span>
           {' dataRoutes '}
           <span className={styles.blue}>=</span>
           {' ['}
-        </p>
-        <p>
+          <br />
           &nbsp;&nbsp;
           <span className={styles.purple}>withErrorBoundary</span>
           (&#123;
-        </p>
-        <p>
+          <br />
           &nbsp;&nbsp;&nbsp;&nbsp;
           <span className={styles.darkBlue}>path</span>
           {': '}
           <span className={styles.blue}>&apos;/path-to-page&apos;</span>
           ,
-        </p>
-        <p>
+          <br />
           &nbsp;&nbsp;&nbsp;&nbsp;
           <span className={styles.darkBlue}>Component</span>
           {': '}
           <span className={styles.orange}>PageComponent</span>
           ,
-        </p>
-        <p>
+          <br />
           &nbsp;&nbsp;&#125;),
-        </p>
-        <p>
+          <br />
           ];
         </p>
       </div>

--- a/pages/Documentation/StartingAProject.tsx
+++ b/pages/Documentation/StartingAProject.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import classNames from 'classnames';
 
 import HeadingBlock from 'app/components/HeadingBlock';
 import ExternalLink from 'app/components/ExternalLink';
@@ -26,22 +25,22 @@ function StartingAProject() {
         <span className={styles.highlight}>package.json</span>
         {' file.'}
       </ChecklistItem>
-      <ChecklistItem className={classNames(styles.indent, styles.checklist)}>
+      <ChecklistItem className={styles.indent}>
         {'Update the '}
         <span className={styles.highlight}>name</span>
         {' field.'}
       </ChecklistItem>
-      <ChecklistItem className={classNames(styles.indent, styles.checklist)}>
+      <ChecklistItem className={styles.indent}>
         {'Update the '}
         <span className={styles.highlight}>repository/url</span>
         {' field.'}
       </ChecklistItem>
-      <ChecklistItem className={classNames(styles.indent, styles.checklist)}>
+      <ChecklistItem className={styles.indent}>
         {'Update the '}
         <span className={styles.highlight}>bugs/url</span>
         {' field.'}
       </ChecklistItem>
-      <ChecklistItem className={classNames(styles.indent, styles.checklist)}>
+      <ChecklistItem className={styles.indent}>
         {'Update the '}
         <span className={styles.highlight}>homepage</span>
         {' field.'}
@@ -59,7 +58,7 @@ function StartingAProject() {
         <span className={styles.highlight}>nvm use</span>
         .
       </ChecklistItem>
-      <ChecklistItem className={classNames(styles.indent, styles.checklist)}>
+      <ChecklistItem className={styles.indent}>
         {'Otherwise, note the contents of '}
         <span className={styles.highlight}>.nvmrc</span>
         {' to see the version of '}

--- a/pages/Documentation/__tests__/__snapshots__/index.test.js.snap
+++ b/pages/Documentation/__tests__/__snapshots__/index.test.js.snap
@@ -3011,9 +3011,8 @@ exports[`Documentation Page Component matches snapshot 1`] = `
           </span>
            [
         </p>
-        <p
-          className="indent"
-        >
+        <p>
+            
           <span
             className="purple"
           >
@@ -3021,9 +3020,8 @@ exports[`Documentation Page Component matches snapshot 1`] = `
           </span>
           ({
         </p>
-        <p
-          className="indent twice"
-        >
+        <p>
+              
           <span
             className="darkBlue"
           >
@@ -3037,9 +3035,8 @@ exports[`Documentation Page Component matches snapshot 1`] = `
           </span>
           ,
         </p>
-        <p
-          className="indent twice"
-        >
+        <p>
+              
           <span
             className="darkBlue"
           >
@@ -3053,10 +3050,8 @@ exports[`Documentation Page Component matches snapshot 1`] = `
           </span>
           ,
         </p>
-        <p
-          className="indent"
-        >
-          }),
+        <p>
+            }),
         </p>
         <p>
           ];

--- a/pages/Documentation/__tests__/__snapshots__/index.test.js.snap
+++ b/pages/Documentation/__tests__/__snapshots__/index.test.js.snap
@@ -290,7 +290,7 @@ exports[`Documentation Page Component matches snapshot 1`] = `
         </label>
       </div>
       <div
-        className="checklistItem indent checklist"
+        className="checklistItem indent"
       >
         <label>
           <input
@@ -341,7 +341,7 @@ exports[`Documentation Page Component matches snapshot 1`] = `
         </label>
       </div>
       <div
-        className="checklistItem indent checklist"
+        className="checklistItem indent"
       >
         <label>
           <input
@@ -392,7 +392,7 @@ exports[`Documentation Page Component matches snapshot 1`] = `
         </label>
       </div>
       <div
-        className="checklistItem indent checklist"
+        className="checklistItem indent"
       >
         <label>
           <input
@@ -443,7 +443,7 @@ exports[`Documentation Page Component matches snapshot 1`] = `
         </label>
       </div>
       <div
-        className="checklistItem indent checklist"
+        className="checklistItem indent"
       >
         <label>
           <input
@@ -605,7 +605,7 @@ exports[`Documentation Page Component matches snapshot 1`] = `
         </label>
       </div>
       <div
-        className="checklistItem indent checklist"
+        className="checklistItem indent"
       >
         <label>
           <input

--- a/pages/Documentation/__tests__/__snapshots__/index.test.js.snap
+++ b/pages/Documentation/__tests__/__snapshots__/index.test.js.snap
@@ -2549,8 +2549,7 @@ exports[`Documentation Page Component matches snapshot 1`] = `
             'app/module'
           </span>
           ;
-        </p>
-        <p>
+          <br />
           <span
             className="red"
           >

--- a/pages/Documentation/__tests__/__snapshots__/index.test.js.snap
+++ b/pages/Documentation/__tests__/__snapshots__/index.test.js.snap
@@ -2948,8 +2948,7 @@ exports[`Documentation Page Component matches snapshot 1`] = `
           >
             // app/dataRoutes/index.ts
           </span>
-        </p>
-        <p>
+          <br />
           <span
             className="red"
           >
@@ -2974,9 +2973,8 @@ exports[`Documentation Page Component matches snapshot 1`] = `
             'pages/PageComponent'
           </span>
           ;
-        </p>
-        <br />
-        <p>
+          <br />
+          <br />
           <span
             className="red"
           >
@@ -2995,9 +2993,8 @@ exports[`Documentation Page Component matches snapshot 1`] = `
             './withErrorBoundary'
           </span>
           ;
-        </p>
-        <br />
-        <p>
+          <br />
+          <br />
           <span
             className="red"
           >
@@ -3010,8 +3007,7 @@ exports[`Documentation Page Component matches snapshot 1`] = `
             =
           </span>
            [
-        </p>
-        <p>
+          <br />
             
           <span
             className="purple"
@@ -3019,8 +3015,7 @@ exports[`Documentation Page Component matches snapshot 1`] = `
             withErrorBoundary
           </span>
           ({
-        </p>
-        <p>
+          <br />
               
           <span
             className="darkBlue"
@@ -3034,8 +3029,7 @@ exports[`Documentation Page Component matches snapshot 1`] = `
             '/path-to-page'
           </span>
           ,
-        </p>
-        <p>
+          <br />
               
           <span
             className="darkBlue"
@@ -3049,11 +3043,9 @@ exports[`Documentation Page Component matches snapshot 1`] = `
             PageComponent
           </span>
           ,
-        </p>
-        <p>
+          <br />
             }),
-        </p>
-        <p>
+          <br />
           ];
         </p>
       </div>

--- a/pages/Documentation/styles.module.scss
+++ b/pages/Documentation/styles.module.scss
@@ -6,10 +6,6 @@ $indent-unit: map.get(var.$content, 'padding');
 .indent {
   margin-left: $indent-unit;
 
-  &.twice {
-    margin-left: calc($indent-unit * 2);
-  }
-
   &.checklist {
     margin-left: calc($indent-unit * 1.5);
   }

--- a/pages/Documentation/styles.module.scss
+++ b/pages/Documentation/styles.module.scss
@@ -4,11 +4,7 @@
 $indent-unit: map.get(var.$content, 'padding');
 
 .indent {
-  margin-left: $indent-unit;
-
-  &.checklist {
-    margin-left: calc($indent-unit * 1.5);
-  }
+  margin-left: calc($indent-unit * 1.5);
 }
 
 .highlight {


### PR DESCRIPTION
## Description
Linked to Issue: #65
Add spaces to the code block in the "Error Boundary" section of the `/documentation` page for those who may select the text via highlight to copy. In order to achieve this, the [HTML character reference](https://developer.mozilla.org/en-US/docs/Glossary/Character_reference) `&nbsp;` are used to render the spaces. In order for these to render correctly from the server response, a [meta tag for the charset](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta#charset) needs to be set to `utf-8` in the document.

The CSS classes `.indent` and `.checklist` no longer need to be consolidated in `pages/Documentation/styles.module.scss` since the code blocks use spaces for indentation now.

## Changes
* Add a meta tag setting `charset` to `utf-8` in `app/App/index.tsx`
* Change indentations to spaces in the code-block in `pages/Documentation/ErrorBoundary.tsx`
* Remove the unnecessary class `.checklist` from indented lines in `pages/Documentation/StartingAProject.tsx`
* Remove unnecessary classes `.checklist` and `.twice` in `pages/Documentation/styles.module.scss`
* Replace usage of multiple `<p>` tags with `<br/>` tags within a single `<p>` tag to avoid double-newlines on copy/paste in `pages/Documentation/AddingAnApplicationDirectory.tsx` and `pages/Documentation/ErrorBoundary.tsx`

## Steps to QA
* Pull down and switch to this branch
* Verify on the `/documentation` page:
  * The section "Starting a Project" looks and behaves the same
  * The code block in the section "Error Boundary" looks the same
    * You can select the text in the code-block by mouse and the spaces are selected. Copying/pasting this code by visual copy/paste copies the correct code.
