### PR TITLE
Bugfix: Create hook `useResetScroll` and component `InternalLink`

### DIFF
--- a/app/components/InternalLink/README.md
+++ b/app/components/InternalLink/README.md
@@ -1,0 +1,4 @@
+# InternalLink
+A simple higher-order component that wraps the [React Router Link](https://reactrouter.com/en/main/components/link) component, ensuring that a [state](https://reactrouter.com/en/main/components/link#state) object property `resetScroll` is set to `true` on the Link component.
+
+This is a convenience component to ensure client-side navigation will reset the browser window scroll on page navigation. This issue is discussed in greater detail in the hook [app/hooks/useResetScroll](app/hooks/README.md#useResetScroll).

--- a/app/components/InternalLink/__tests__/__snapshots__/index.test.js.snap
+++ b/app/components/InternalLink/__tests__/__snapshots__/index.test.js.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`InternalLink component matches the snapshot 1`] = `
+<a
+  href="/test"
+  onClick={[Function]}
+/>
+`;
+
+exports[`InternalLink component matches the snapshot with existing state 1`] = `
+<a
+  href="/test-state"
+  onClick={[Function]}
+/>
+`;

--- a/app/components/InternalLink/__tests__/__snapshots__/index.test.js.snap
+++ b/app/components/InternalLink/__tests__/__snapshots__/index.test.js.snap
@@ -1,15 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`InternalLink component matches the snapshot 1`] = `
-<a
-  href="/test"
-  onClick={[Function]}
-/>
-`;
-
-exports[`InternalLink component matches the snapshot with existing state 1`] = `
-<a
-  href="/test-state"
-  onClick={[Function]}
-/>
+<div>
+  <p
+    data-testid="to"
+  >
+    "/test"
+  </p>
+  <p
+    data-testid="state"
+  >
+    {"resetScroll":true}
+  </p>
+</div>
 `;

--- a/app/components/InternalLink/__tests__/index.test.js
+++ b/app/components/InternalLink/__tests__/index.test.js
@@ -1,27 +1,83 @@
 import React from 'react';
-import { MemoryRouter } from 'react-router-dom';
 import renderer from 'react-test-renderer';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
 
+import { ResetScrollKey } from 'app/hooks/useResetScroll';
 import InternalLink from '../index';
 
-function RouterWrappedLink(props) {
+function RenderProp({ k, v }) {
   return (
-    <MemoryRouter>
-      <InternalLink {...props} />
-    </MemoryRouter>
+    <p data-testid={`${k}`}>{v}</p>
   );
 }
 
+function MockedLink(props) {
+  return (
+    <div>
+      { Object.entries(props).map(function renderEachProp([key, value]) {
+        const val = JSON.stringify(value);
+        return <RenderProp key={key} k={key} v={val} />;
+      }) }
+    </div>
+  );
+}
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  Link: MockedLink,
+}));
+
+const expectedStateContent = {
+  [ResetScrollKey]: true,
+};
+
 describe('InternalLink component', () => {
   test('matches the snapshot', () => {
-    const tree = renderer.create(<RouterWrappedLink to="/test" />).toJSON();
+    const tree = renderer.create(<InternalLink to="/test" />).toJSON();
 
     expect(tree).toMatchSnapshot();
   });
 
-  test('matches the snapshot with existing state', () => {
-    const tree = renderer.create(<RouterWrappedLink to="/test-state" state={{ unrelated: 'stateval' }} />).toJSON();
+  test('passes all properties through to React Router Link', () => {
+    const props = {
+      to: '/test-props',
+      children: 'nested-elements',
+      foo: 'bar',
+      hello: 'compositional component!',
+    };
 
-    expect(tree).toMatchSnapshot();
+    render(<InternalLink {...props} />);
+
+    for (const [key, value] of Object.entries(props)) {
+      const $el = screen.queryByTestId(key);
+
+      expect($el).toBeInTheDocument();
+      expect($el).toHaveTextContent(JSON.stringify(value));
+    }
+  });
+
+  test('adds a state object to trigger scroll reset', () => {
+    const targetPath = '/test-state-applied';
+
+    render(<InternalLink to={targetPath} />);
+
+    expect(screen.queryByTestId('to')).toHaveTextContent(targetPath);
+    expect(screen.queryByTestId('state')).toHaveTextContent(JSON.stringify(expectedStateContent));
+  });
+
+  test('extends provided state object with trigger for scroll reset', () => {
+    const targetPath = '/test-state-extended';
+    const initialStateObject = {
+      some: 'state',
+    };
+
+    render(<InternalLink to={targetPath} state={initialStateObject} />);
+
+    expect(screen.queryByTestId('to')).toHaveTextContent(targetPath);
+    expect(screen.queryByTestId('state')).toHaveTextContent(JSON.stringify({
+      ...initialStateObject,
+      ...expectedStateContent,
+    }));
   });
 });

--- a/app/components/InternalLink/__tests__/index.test.js
+++ b/app/components/InternalLink/__tests__/index.test.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import renderer from 'react-test-renderer';
+
+import InternalLink from '../index';
+
+function RouterWrappedLink(props) {
+  return (
+    <MemoryRouter>
+      <InternalLink {...props} />
+    </MemoryRouter>
+  );
+}
+
+describe('InternalLink component', () => {
+  test('matches the snapshot', () => {
+    const tree = renderer.create(<RouterWrappedLink to="/test" />).toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('matches the snapshot with existing state', () => {
+    const tree = renderer.create(<RouterWrappedLink to="/test-state" state={{ unrelated: 'stateval' }} />).toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/app/components/InternalLink/index.tsx
+++ b/app/components/InternalLink/index.tsx
@@ -9,22 +9,14 @@ interface InternalLinkProps extends Omit<LinkProps, 'state'> {
 }
 
 function InternalLink(props: InternalLinkProps) {
-  const resetScrollState = {
-    [ResetScrollKey]: true,
-  };
-
   const { state } = props;
 
   const propsWithState = {
     ...props,
-    ...(typeof state === 'undefined' ? {
-      state: resetScrollState,
-    } : {
-      state: {
-        ...state,
-        ...resetScrollState,
-      },
-    }),
+    state: {
+      ...(typeof state !== 'undefined' ? state : {}),
+      [ResetScrollKey]: true,
+    },
   };
 
   return (

--- a/app/components/InternalLink/index.tsx
+++ b/app/components/InternalLink/index.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import type { LinkProps } from 'react-router-dom';
+
+import { ResetScrollKey } from 'app/hooks/useResetScroll';
+
+interface InternalLinkProps extends Omit<LinkProps, 'state'> {
+  state?: { [key: string]: any };
+}
+
+function InternalLink(props: InternalLinkProps) {
+  const resetScrollState = {
+    [ResetScrollKey]: true,
+  };
+
+  const { state } = props;
+
+  const propsWithState = {
+    ...props,
+    ...(typeof state === 'undefined' ? {
+      state: resetScrollState,
+    } : {
+      state: {
+        ...state,
+        ...resetScrollState,
+      },
+    }),
+  };
+
+  return (
+    <Link {...propsWithState} />
+  );
+}
+
+export default InternalLink;

--- a/app/hooks/README.md
+++ b/app/hooks/README.md
@@ -24,3 +24,16 @@ import InternalLink from 'app/components/InternalLink';
 After resetting the scroll, this hook will replace the current [location state](https://reactrouter.com/en/main/start/concepts#definitions) with the same path removing the `resetScroll` state. The result of this is:
 * Upon clicking a link with the `resetScroll` state will navigate the page and reset the page scroll.
 * Using browser navigation (back/forward buttons) to return to a page that had its scroll reset will not reset the scroll, preserving the user's scroll position on the page.
+
+### Hash Links
+`useScrollReset` will behave differently when the `resetScroll` flag is present in the location state if the location contains a hash: instead of scrolling to the top-left of the window, it will instead scroll the element whose `id` attribute matches the hash into view.
+
+```javascript
+import InternalLink from 'app/components/InternalLink';
+
+<InternalLink to="/internal-path#page-section">
+  Scroll to element with id "page-section" on navigation
+</InternalLink>
+```
+
+If the target page does not contain an element whose `id` attribute matches the location hash, this hook will scroll the browser to the top-left of the window instead.

--- a/app/hooks/README.md
+++ b/app/hooks/README.md
@@ -1,0 +1,26 @@
+# Hooks
+This directory houses [custom React hooks](https://react.dev/learn/reusing-logic-with-custom-hooks) created for the boilerplate.
+
+## useScrollReset
+
+[useScrollReset](./useResetScroll.ts) is a hook created specifically for Layout components that utilize the [React Router Outlet](https://reactrouter.com/en/main/components/outlet). [Links](https://reactrouter.com/en/main/components/link) that navigate between pages under the same layout do not reset the browser window's scroll position upon navigation. To remedy this, this hook will be used to explicitly trigger a scroll reset back to the top-left of the browser window upon route change.
+
+This scroll reset only triggers when a location change carries with it a specific flag in a location [state](https://reactrouter.com/en/main/components/link#state) object:
+
+```javascript
+import { Link } from 'react-router-dom';
+
+<Link to="/internal-path" state={{ resetScroll: true }}>Reset scroll on navigation</Link>
+```
+
+This state object flag, `resetScroll`, can be applied automatically by using the reusable component [app/components/InternalLink](../components/InternalLink):
+
+```javascript
+import InternalLink from 'app/components/InternalLink';
+
+<InternalLink to="/internal-path">Reset scroll on Navigation</InternalLink>
+```
+
+After resetting the scroll, this hook will replace the current [location state](https://reactrouter.com/en/main/start/concepts#definitions) with the same path removing the `resetScroll` state. The result of this is:
+* Upon clicking a link with the `resetScroll` state will navigate the page and reset the page scroll.
+* Using browser navigation (back/forward buttons) to return to a page that had its scroll reset will not reset the scroll, preserving the user's scroll position on the page.

--- a/app/hooks/__tests__/useResetScroll.test.js
+++ b/app/hooks/__tests__/useResetScroll.test.js
@@ -1,0 +1,121 @@
+import { useLayoutEffect } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import '@testing-library/jest-dom';
+
+import useResetScroll, { ResetScrollKey } from '../useResetScroll';
+
+jest.mock('react', () => ({
+  ...jest.requireActual('react'),
+  useLayoutEffect: jest.fn(),
+}));
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useLocation: jest.fn(),
+  useNavigate: jest.fn(),
+}));
+
+const mockedNavigate = jest.fn();
+const mockedLocation = {
+  pathname: '/mocked',
+};
+const mockedScrollTo = jest.fn();
+
+describe('useResetScroll', () => {
+  beforeAll(() => {
+    useNavigate.mockReturnValue(mockedNavigate);
+    useLocation.mockReturnValue(mockedLocation);
+    global.document.documentElement.scrollTo = mockedScrollTo;
+  });
+
+  beforeEach(() => {
+    useLayoutEffect.mockClear();
+    useLocation.mockClear();
+    useNavigate.mockClear();
+    mockedNavigate.mockClear();
+    mockedScrollTo.mockClear();
+  });
+
+  afterAll(() => {
+    delete global.document.documentElement.scrollTo;
+  });
+
+  test('assigns handler to useLayoutEffect, watching location.pathname', () => {
+    useResetScroll();
+
+    expect(useLocation).toHaveBeenCalledTimes(1);
+    expect(useNavigate).toHaveBeenCalledTimes(1);
+    expect(mockedNavigate).toHaveBeenCalledTimes(0);
+    expect(mockedScrollTo).toHaveBeenCalledTimes(0);
+    expect(useLayoutEffect).toHaveBeenCalledTimes(1);
+
+    expect(useLayoutEffect).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.arrayContaining([mockedLocation.pathname]),
+    );
+  });
+
+  test('does not scroll document if location state doesn\'t exist', () => {
+    useResetScroll();
+
+    const [effectHandler] = useLayoutEffect.mock.calls[0];
+    effectHandler();
+
+    expect(mockedScrollTo).not.toHaveBeenCalled();
+    expect(mockedNavigate).not.toHaveBeenCalled();
+  });
+
+  test('does not scroll document if location state resetScroll property is set to false', () => {
+    mockedLocation.state = {
+      [ResetScrollKey]: false,
+    };
+
+    useResetScroll();
+
+    const [effectHandler] = useLayoutEffect.mock.calls[0];
+    effectHandler();
+
+    expect(mockedScrollTo).not.toHaveBeenCalled();
+    expect(mockedNavigate).not.toHaveBeenCalled();
+
+    delete mockedLocation.state;
+  });
+
+  describe('location.state.scrollReset set to true', () => {
+    beforeAll(() => {
+      mockedLocation.state = {
+        [ResetScrollKey]: true,
+      };
+    });
+
+    afterAll(() => {
+      delete mockedLocation.state;
+    });
+
+    test('handler scrolls the document to the top-left', () => {
+      useResetScroll();
+
+      const [effectHandler] = useLayoutEffect.mock.calls[0];
+      effectHandler();
+
+      expect(mockedScrollTo).toHaveBeenCalledTimes(1);
+      expect(mockedScrollTo).toHaveBeenCalledWith(expect.objectContaining({
+        top: 0,
+        left: 0,
+        behavior: 'instant',
+      }));
+    });
+
+    test('handler replaces the history with the same path, eliminating the location state', () => {
+      useResetScroll();
+
+      const [effectHandler] = useLayoutEffect.mock.calls[0];
+      effectHandler();
+
+      expect(mockedNavigate).toHaveBeenCalledTimes(1);
+      expect(mockedNavigate).toHaveBeenCalledWith(mockedLocation.pathname, expect.objectContaining({
+        replace: true,
+      }));
+    });
+  });
+});

--- a/app/hooks/useResetScroll.ts
+++ b/app/hooks/useResetScroll.ts
@@ -1,0 +1,23 @@
+import { useLayoutEffect } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+
+export const ResetScrollKey = 'resetScroll';
+
+function useResetScroll() {
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  useLayoutEffect(function resetScrollPosition() {
+    if (location.state?.[ResetScrollKey]) {
+      document.documentElement.scrollTo({
+        top: 0,
+        left: 0,
+        behavior: 'instant',
+      });
+
+      navigate(location.pathname, { replace: true });
+    }
+  }, [location.pathname]);
+}
+
+export default useResetScroll;

--- a/app/hooks/useResetScroll.ts
+++ b/app/hooks/useResetScroll.ts
@@ -9,15 +9,24 @@ function useResetScroll() {
 
   useLayoutEffect(function resetScrollPosition() {
     if (location.state?.[ResetScrollKey]) {
-      document.documentElement.scrollTo({
-        top: 0,
-        left: 0,
-        behavior: 'instant',
-      });
+      const IdFromHash = location.hash.slice(1);
+      const $hashEl = document.getElementById(IdFromHash);
 
-      navigate(location.pathname, { replace: true });
+      if ($hashEl) {
+        $hashEl.scrollIntoView(true);
+      } else {
+        document.documentElement.scrollTo({
+          top: 0,
+          left: 0,
+          behavior: 'instant',
+        });
+      }
+
+      navigate(`${location.pathname}${location.hash}`, {
+        replace: true,
+      });
     }
-  }, [location.pathname]);
+  }, [location.pathname, location.hash]);
 }
 
 export default useResetScroll;

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,6 +44,7 @@
 * [Static Files](#static-files)
 * [Error Boundary](#error-boundary)
 * [Testing](#testing)
+* [Application Layouts](#application-layouts)
 * [Pull Request Template](#pull-request-template)
 * [Github Workflow](#github-workflow)
 
@@ -123,6 +124,15 @@ Alternatively, keep the error page path and just replace the [ErrorPage componen
 The default [coverage threshhold](https://jestjs.io/docs/configuration#coveragethreshold-object) is set to 100% across the board. To reduce or remove the test coverage requirements, modify the `coverageThreshold` field in the [config](../jest.config.js).
 
 To run the test suite locally: `npm test`. To update [Jest snapshots](https://jestjs.io/docs/snapshot-testing) `npm run test:snapshot` can be used. Alternatively, `npm run test -- -u` will also work.
+
+### Application Layouts
+Layouts can be applied directly to routes in [React Router](https://reactrouter.com/en/main) using [Layout Routes](https://reactrouter.com/en/main/start/concepts#layout-routes).
+
+In the boilerplate, a default Layout has been created in [pages/Layout](../pages/Layout).
+
+One issue that has arisen from the usage of a layout route is that client-side navigation will not reset the browser scroll upon page navigation: clicking a link to another page will land the user on the new page, scrolled the same amount as on the previous page.
+
+A solution has been implemented in this boilerplate in the form of a [custom React hook](https://react.dev/learn/reusing-logic-with-custom-hooks): [useResetScroll](../app/hooks/README.md#useResetScroll). This hook needs to be invoked by any layout route component used to be put into effect, and [Links](https://reactrouter.com/en/main/components/link) to pages that need the scroll reset need to pass a [state](https://reactrouter.com/en/main/components/link#state) object with a property `resetScroll` set to `true`. A reusable component [InternalLink](../app/components/InternalLink) has been provided to automatically pass this state object property.
 
 ### Pull Request Template
 **Tamsui** contains a [Github Pull Request template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository) that is intended to provide a scaffold for a thorough pull request. [This template](../.github/pull_request_template.md) provides the following sections:

--- a/pages/Documentation/__tests__/__snapshots__/index.test.js.snap
+++ b/pages/Documentation/__tests__/__snapshots__/index.test.js.snap
@@ -64,28 +64,32 @@ exports[`Documentation Page Component matches snapshot 1`] = `
       >
         <li>
           <a
-            href="#Starting-a-Project"
+            href="/#Starting-a-Project"
+            onClick={[Function]}
           >
             Starting a Project
           </a>
         </li>
         <li>
           <a
-            href="#NPM-Scripts"
+            href="/#NPM-Scripts"
+            onClick={[Function]}
           >
             NPM Scripts
           </a>
         </li>
         <li>
           <a
-            href="#Developing-Locally"
+            href="/#Developing-Locally"
+            onClick={[Function]}
           >
             Developing Locally
           </a>
         </li>
         <li>
           <a
-            href="#Building-for-Production"
+            href="/#Building-for-Production"
+            onClick={[Function]}
           >
             Building for Production
           </a>
@@ -2113,56 +2117,64 @@ exports[`Documentation Page Component matches snapshot 1`] = `
       >
         <li>
           <a
-            href="#Running-the-Application"
+            href="/#Running-the-Application"
+            onClick={[Function]}
           >
             Running the Application
           </a>
         </li>
         <li>
           <a
-            href="#Project-Directories"
+            href="/#Project-Directories"
+            onClick={[Function]}
           >
             Project Directories
           </a>
         </li>
         <li>
           <a
-            href="#Adding-an-Application-Directory"
+            href="/#Adding-an-Application-Directory"
+            onClick={[Function]}
           >
             Adding an Application Directory
           </a>
         </li>
         <li>
           <a
-            href="#Static-Files"
+            href="/#Static-Files"
+            onClick={[Function]}
           >
             Static Files
           </a>
         </li>
         <li>
           <a
-            href="#Error-Boundary"
+            href="/#Error-Boundary"
+            onClick={[Function]}
           >
             Error Boundary
           </a>
         </li>
         <li>
           <a
-            href="#Testing"
+            href="/#Testing"
+            onClick={[Function]}
           >
             Testing
           </a>
         </li>
         <li>
           <a
-            href="#Pull-Request-Template"
+            href="/#Pull-Request-Template"
+            onClick={[Function]}
           >
             Pull Request Template
           </a>
         </li>
         <li>
           <a
-            href="#Github-Workflow"
+            href="/#Github-Workflow"
+            onClick={[Function]}
           >
             Github Workflow
           </a>

--- a/pages/Documentation/index.tsx
+++ b/pages/Documentation/index.tsx
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 import ContentBlock from 'app/components/ContentBlock';
 import HeadingBlock from 'app/components/HeadingBlock';
 import ExternalLink from 'app/components/ExternalLink';
+import InternalLink from 'app/components/InternalLink';
 
 import StartingAProject from './StartingAProject';
 import NPMScripts from './NPMScripts';
@@ -40,16 +41,16 @@ function Documentation() {
       >
         <ul className={classNames(styles.list, styles.content)}>
           <li>
-            <a href="#Starting-a-Project">Starting a Project</a>
+            <InternalLink to="#Starting-a-Project">Starting a Project</InternalLink>
           </li>
           <li>
-            <a href="#NPM-Scripts">NPM Scripts</a>
+            <InternalLink to="#NPM-Scripts">NPM Scripts</InternalLink>
           </li>
           <li>
-            <a href="#Developing-Locally">Developing Locally</a>
+            <InternalLink to="#Developing-Locally">Developing Locally</InternalLink>
           </li>
           <li>
-            <a href="#Building-for-Production">Building for Production</a>
+            <InternalLink to="#Building-for-Production">Building for Production</InternalLink>
           </li>
         </ul>
       </HeadingBlock>
@@ -64,28 +65,28 @@ function Documentation() {
       >
         <ul className={classNames(styles.list, styles.content)}>
           <li>
-            <a href="#Running-the-Application">Running the Application</a>
+            <InternalLink to="#Running-the-Application">Running the Application</InternalLink>
           </li>
           <li>
-            <a href="#Project-Directories">Project Directories</a>
+            <InternalLink to="#Project-Directories">Project Directories</InternalLink>
           </li>
           <li>
-            <a href="#Adding-an-Application-Directory">Adding an Application Directory</a>
+            <InternalLink to="#Adding-an-Application-Directory">Adding an Application Directory</InternalLink>
           </li>
           <li>
-            <a href="#Static-Files">Static Files</a>
+            <InternalLink to="#Static-Files">Static Files</InternalLink>
           </li>
           <li>
-            <a href="#Error-Boundary">Error Boundary</a>
+            <InternalLink to="#Error-Boundary">Error Boundary</InternalLink>
           </li>
           <li>
-            <a href="#Testing">Testing</a>
+            <InternalLink to="#Testing">Testing</InternalLink>
           </li>
           <li>
-            <a href="#Pull-Request-Template">Pull Request Template</a>
+            <InternalLink to="#Pull-Request-Template">Pull Request Template</InternalLink>
           </li>
           <li>
-            <a href="#Github-Workflow">Github Workflow</a>
+            <InternalLink to="#Github-Workflow">Github Workflow</InternalLink>
           </li>
         </ul>
       </HeadingBlock>

--- a/pages/Home/index.tsx
+++ b/pages/Home/index.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
 
 import HeroBanner from 'app/components/HeroBanner';
 import ContentBlock from 'app/components/ContentBlock';
 import HeadingBlock from 'app/components/HeadingBlock';
 import ExternalLink from 'app/components/ExternalLink';
+import InternalLink from 'app/components/InternalLink';
 
 import styles from './styles.module.scss';
 
@@ -152,7 +152,7 @@ function Home(): React.ReactElement {
         <HeadingBlock id="Usage" level="2" heading="Usage">
           <p>
             {'Usage documentation is provided on the '}
-            <Link to="/documentation">Documentation page</Link>
+            <InternalLink to="/documentation">Documentation page</InternalLink>
             .
           </p>
         </HeadingBlock>

--- a/pages/Layout/Nav.tsx
+++ b/pages/Layout/Nav.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import classNames from 'classnames';
-import { Link } from 'react-router-dom';
 
 import Logo from 'app/components/Logo';
 import ExternalLink from 'app/components/ExternalLink';
+import InternalLink from 'app/components/InternalLink';
 
 import styles from './styles.nav.module.scss';
 
@@ -12,15 +12,15 @@ function Nav() {
     <nav className={styles.navbar}>
       <div className={styles.contents}>
         <div className={classNames(styles.segment, styles.home)}>
-          <Link className={styles.menuLink} to="/">
+          <InternalLink className={styles.menuLink} to="/">
             <Logo className={styles.logo} height="30px" />
             <span>Tamsui</span>
-          </Link>
+          </InternalLink>
         </div>
         <div className={classNames(styles.segment, styles.pages)}>
-          <Link className={styles.menuLink} to="/documentation">
+          <InternalLink className={styles.menuLink} to="/documentation">
             Documentation
-          </Link>
+          </InternalLink>
         </div>
         <div className={classNames(styles.segment, styles.social)}>
           <ExternalLink href="https://github.com/chichiwang/tamsui">

--- a/pages/Layout/__tests__/index.test.js
+++ b/pages/Layout/__tests__/index.test.js
@@ -1,8 +1,12 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
 import { MemoryRouter } from 'react-router-dom';
+import { render } from '@testing-library/react';
+import useResetScroll from 'app/hooks/useResetScroll';
 
 import Layout from '../index';
+
+jest.mock('app/hooks/useResetScroll', () => jest.fn());
 
 function RouterWrappedLayout() {
   return (
@@ -13,9 +17,19 @@ function RouterWrappedLayout() {
 }
 
 describe('Layout Component - default', () => {
+  beforeEach(() => {
+    useResetScroll.mockRestore();
+  });
+
   test('matches no-child snapshot', () => {
     const tree = renderer.create(<RouterWrappedLayout />).toJSON();
 
     expect(tree).toMatchSnapshot();
+  });
+
+  test('invokes the useResetScroll hook', () => {
+    render(<RouterWrappedLayout />);
+
+    expect(useResetScroll).toHaveBeenCalledTimes(1);
   });
 });

--- a/pages/Layout/index.tsx
+++ b/pages/Layout/index.tsx
@@ -1,11 +1,15 @@
 import React from 'react';
 import { Outlet } from 'react-router-dom';
 
+import useResetScroll from 'app/hooks/useResetScroll';
+
 import Nav from './Nav';
 
 import styles from './styles.module.scss';
 
 function Layout() {
+  useResetScroll();
+
   return (
     <section className={styles.page}>
       <Nav />


### PR DESCRIPTION
## Description
Linked to Issue: #116 

### Issue
Clicking on a link to an internal page navigates to the page, but does not reset the scrollbar to the top of the page after the page transition. This results in strange behavior where you can click on a link on one page, and end up scrolled down by the same amount on the next page.

### Solution
Taking some inspiration from [an article on ensuring scroll reset within layouts](https://dev.to/kingjames_x/how-to-fix-react-routers-scroll-position-on-page-transitions-7cb), we create a custom React hook `useResetScroll` and invoke it in our layout. This introduces a new issue: every page navigation will reset the scroll position, including using the browser's back/forward buttons. This is unwanted behavior.

To solve this we put the reset-scroll behavior behind an explicit flag, passed through React Router's [location state](https://reactrouter.com/en/main/components/link#state) called `resetScroll`. We only reset the scroll bar if this value is set to `true`: thus all internal links should contain this flag.

If the path contains a hash value that corresponds to an element id on the target page, we [scroll the element into view](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView) instead.

Location states are preserved in the [history stack](https://reactrouter.com/en/main/start/concepts#history-stack), meaning that any page visited via a link that passes this flag will carry this flag on browser back/forward navigation. So if a user clicks on an internal link that passes `resetScroll`, scrolls down manually, hits the back button, then the forward button - they will end up back at the top of the page.

To solve this, we replace the history state with the same page, but remove the reset scroll.

A convenience component, `InternalLink` is created to automatically apply this `resetScroll` state to a React Router Link component.

Documentation has been created to explain how to create Layout Routes, the use of the `useResetScroll` hook, and the purpose of the `InternalLink` component.

## Changes
* `app/components/InternalLink/README.md` added to provide a brief description of the new `InternalLink` component
* `app/components/InternalLink/index.tsx` added to automatically apply a `resetScroll` state to a [React Router link](https://reactrouter.com/en/main/components/link)
* `app/hooks/README.md` added to document the behavior and usage of hooks
  * Documentation for the behavior/usage of `useResetScroll` hook created
* `app/hooks/useResetScroll.ts` created to provide scroll behavior on location path and hash change
  * Only when provided a flag `resetScroll` in the location state
  * Export a variable `ResetScrollKey` containing the string property name of the scroll reset flag
* Add a new section "Application Layouts" to `docs/README.md`
  * Document the default layout provided in the boilerplate
  * Note the custom hook `useResetScroll` for use in layouts
  * Note the custom component `InternalLink` for use in the application
* Replace all anchor tags with `InternalLink` components in `pages/Documentation/index.tsx`
* Replace `Link` component with `InternalLink` component in `pages/Home/index.tsx`
* Replace `Link` components with `InternalLink` components in `pages/Layout/Nav.tsx`
* Invoke the `useResetScroll` hook in `pages/Layout/index.tsx`

## Steps to QA
* Pull down and switch to this branch
* Run the application and verify in browser:
  * Internal links in the nav continues to work (project logo, "Documentation" link)
  * The link to the `/documentation` page in the final section of `/` works and scrolls to the top of `/documentation` upon navigation
    * Using browser back/forward buttons preserves the user's scroll position on each page
  * All of the table of content links on `/documentation` works
    * Using the browser back/forward buttons preserve the user's scroll position within the page, between the sections