### PR TITLE
Use `project-configs.js` to define server port based on build environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ dist/
 # Development Workflow Files
 __coverage__/
 stats.json
+project-configs.js
 
 # Dependencies
 node_modules/

--- a/app/global.module.scss
+++ b/app/global.module.scss
@@ -35,7 +35,7 @@
 
 :global p {
   font-size: 1.125rem;
-  line-height: 1.5rem;
+  line-height: 1.75rem;
 }
 
 @viewport {

--- a/app/globals.d.ts
+++ b/app/globals.d.ts
@@ -1,1 +1,3 @@
 declare module '*.module.scss';
+
+declare const PORT: number;

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@
 - [ ] If using [nvm](https://github.com/nvm-sh/nvm), run `nvm use`.
   - [ ] Otherwise, note the contents of `.nvmrc` to see the version of [Node.js](https://nodejs.org/) this project is built on.
 - [ ] Run `npm install`.
+- [ ] Run `npm run create-config` to initialize the configuration file `project-configs.js`.
 
 ## NPM Scripts
 | Script          | Description                                                                                                                                        |
@@ -28,6 +29,7 @@
 | `build:prod`    | Build prod assets and generate `stats.json`                                                                                                        |
 | `build:static`  | Copy the `static/` directory in project root into `dist/`                                                                                          | 
 | `clean`         | Remove `stats.json` and `dist/` directory                                                                                                          |
+| `create-config` | Copies `project-configs-example.js` to `project-configs.js` in the root directory only if it doesn't already exist                                 |
 | `dev`           | Build dev assets and run the webserver, running server logs through [pino-pretty](https://github.com/pinojs/pino-pretty) for development purposes  |
 | `lint`          | Run [ESLint](https://eslint.org/)                                                                                                                  |
 | `prod`          | Build prod assets and run the webserver, running server logs through [pino-pretty](https://github.com/pinojs/pino-pretty) for development purposes |

--- a/docs/README.md
+++ b/docs/README.md
@@ -82,7 +82,7 @@ Then add a [type declaration](https://www.typescriptlang.org/docs/handbook/2/typ
 declare const NEW_CONFIG: boolean;
 ```
 
-Now `NEW_CONFIG` can be used in the project code. When building for development instances of `NEW_CONFIG` will be replaced with `false`, when building for production instances will be replaced with `true`.
+Now `NEW_CONFIG` can be used in the project code. When building for development, instances of `NEW_CONFIG` will be replaced with `false`, when building for production instances will be replaced with `true`.
 
 **Note**: String values must be double-wrapped in quotes, since all config values are passed into the [DefinePlugin](https://webpack.js.org/plugins/define-plugin/#usage). This means that string values are treated as code fragments. Calling `JSON.stringify()` on string values will also preserve them as strings:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,6 +40,7 @@
 | `watch`         | Run watch server, will restart the server on every file change                                                                                     |
 
 ## Developing Locally
+* [Project Configurations](#project-configurations)
 * [Running the Application](#running-the-application)
 * [Project Directories](#project-directories)
 * [Adding an Application Directory](#adding-an-application-directory)
@@ -49,6 +50,58 @@
 * [Application Layouts](#application-layouts)
 * [Pull Request Template](#pull-request-template)
 * [Github Workflow](#github-workflow)
+
+### Project Configurations
+**Tamsui** uses environment-aware configurations via [Webpack's DefinePlugin](https://webpack.js.org/plugins/define-plugin/). This behavior is instrumented in [webpack/define.js](../webpack/define.js).
+
+A sample config file `project-configs-example.js` is provided in the project root directory. Running `npm run create-config` will copy `project-configs-example.js` to `project-configs.js` if it doesn't already exist.
+
+The application will not build without a `project-configs.js` file in the project root: the boilerplate application relies on the `PORT` value being defined as a project configuration variable.
+
+**Adding configuration variables**
+
+To add a configuration variable, add the variable as a property to `project-configs.js`, in both defined environments:
+
+```javascript
+// project-configs.js
+module.exports = {
+  development: {
+    NEW_CONFIG: false,
+  },
+  production: {
+    NEW_CONFIG: true,
+  },
+};
+```
+
+Then add a [type declaration](https://www.typescriptlang.org/docs/handbook/2/type-declarations.html) for the new configuration variable to [app/global.d.ts](../app/globals.d.ts):
+
+```javascript
+// app/global.d.ts
+
+declare const NEW_CONFIG: boolean;
+```
+
+Now `NEW_CONFIG` can be used in the project code. When building for development the value of `NEW_CONFIG` will be set to `false`, when building for production the value will be set to `true`.
+
+**Note**: String values must be double-wrapped in quotes, since all config values are passed into the [DefinePlugin](https://webpack.js.org/plugins/define-plugin/#usage). This means that string values are treated as code fragments. Calling `JSON.stringify()` on string values will also preserve them as strings:
+
+```javascript
+// project-configs.js
+module.exports = {
+  development: {
+    DOUBLE_WRAPPED_STRING: "'string value'",
+    JSON_WRAPPED_STRING: JSON.stringify('remains a string'),
+  },
+  production: {
+    // ...
+  },
+};
+```
+
+**Testing with configuration variables**
+
+New configuration variables can either be mocked into tests by modifying the `global` object, or adding the variable to the [Jest globals object](https://jestjs.io/docs/configuration#globals-object). The globals object can be added to `sharedConfigs`, `appConfig`, `clientConfig`, or `serverConfig` (as appropriate) in [jest.config.js](../jest.config.js).
 
 ### Running the Application
 Run `npm run watch` to run the development watch server.

--- a/docs/README.md
+++ b/docs/README.md
@@ -76,18 +76,19 @@ module.exports = {
 
 Then add a [type declaration](https://www.typescriptlang.org/docs/handbook/2/type-declarations.html) for the new configuration variable to [app/global.d.ts](../app/globals.d.ts):
 
-```javascript
+```typescript
 // app/global.d.ts
 
 declare const NEW_CONFIG: boolean;
 ```
 
-Now `NEW_CONFIG` can be used in the project code. When building for development the value of `NEW_CONFIG` will be set to `false`, when building for production the value will be set to `true`.
+Now `NEW_CONFIG` can be used in the project code. When building for development instances of `NEW_CONFIG` will be replaced with `false`, when building for production instances will be replaced with `true`.
 
 **Note**: String values must be double-wrapped in quotes, since all config values are passed into the [DefinePlugin](https://webpack.js.org/plugins/define-plugin/#usage). This means that string values are treated as code fragments. Calling `JSON.stringify()` on string values will also preserve them as strings:
 
 ```javascript
 // project-configs.js
+
 module.exports = {
   development: {
     DOUBLE_WRAPPED_STRING: "'string value'",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "prebuild:static": "npm run build:dist",
     "build:static": "cp -r static dist/static",
     "clean": "rm -f stats.json && rm -rf dist",
+    "create-config": "[ -f project-configs.js ] || cp project-configs-example.js project-configs.js",
     "dev": "run-s build:dev run | pino-pretty -c -S",
     "lint": "eslint --ext .js,.jsx,.mjs,.ts,.tsx .",
     "prod": "run-s build:prod run | pino-pretty -c -S",

--- a/pages/Documentation/NPMScripts.tsx
+++ b/pages/Documentation/NPMScripts.tsx
@@ -156,6 +156,24 @@ function NPMScripts() {
           <tr>
             <td>
               <div className={styles.script}>
+                <span className={styles.highlight}>create-config</span>
+                <CopyButton className={styles.copyButton} textToCopy="npm run create-config" />
+              </div>
+            </td>
+            <td>
+              <p>
+                {'Copies '}
+                <span className={styles.highlight}>project-configs-example.js</span>
+                {' to '}
+                <span className={styles.highlight}>project-configs.js</span>
+                {' in the root directory only if it doesn\'t already exist'}
+              </p>
+            </td>
+          </tr>
+
+          <tr>
+            <td>
+              <div className={styles.script}>
                 <span className={styles.highlight}>dev</span>
                 <CopyButton className={styles.copyButton} textToCopy="npm run dev" />
               </div>

--- a/pages/Documentation/ProjectConfigurations.tsx
+++ b/pages/Documentation/ProjectConfigurations.tsx
@@ -1,0 +1,263 @@
+import React from 'react';
+
+import HeadingBlock from 'app/components/HeadingBlock';
+import ExternalLink from 'app/components/ExternalLink';
+import CopyButton, { ColorModes } from 'app/components/CopyButton';
+
+import styles from './styles.module.scss';
+
+const configSnippet = `// project-configs.js
+
+module.exports = {
+  development: {
+    NEW_CONFIG: false,
+  },
+  production: {
+    NEW_CONFIG: true,
+  },
+};`;
+
+const declarationSnippet = `// app/global.d.ts
+
+declare const NEW_CONFIG: boolean;`;
+
+const stringsSnippet = `// project-configs.js
+
+module.exports = {
+  development: {
+    DOUBLE_WRAPPED_STRING: "'string value'",
+    JSON_WRAPPED_STRING: JSON.stringify('remains a string'),
+  },
+  production: {
+    // ...
+  },
+};`;
+
+function ProjectConfigurations() {
+  return (
+    <HeadingBlock
+      level="3"
+      id="Project-Configurations"
+      heading="Project Configurations"
+    >
+      <p>
+        <b>Tamsui</b>
+        {' uses environment-aware configurations via '}
+        <ExternalLink href="https://webpack.js.org/plugins/define-plugin/">
+          Webpack&apos;s DefinePlugin
+        </ExternalLink>
+        {'. This behavior is instrumented in '}
+        <ExternalLink href="https://github.com/chichiwang/tamsui/blob/main/webpack/define.js">
+          webpack/define.js
+        </ExternalLink>
+        .
+      </p>
+
+      <p>
+        {'A sample config file '}
+        <span className={styles.highlight}>project-configs-example.js</span>
+        {' is provided in the project root directory. Running '}
+        <span className={styles.highlight}>npm run create-config</span>
+        {' will copy '}
+        <span className={styles.highlight}>project-configs-example.js</span>
+        {' to '}
+        <span className={styles.highlight}>project-configs.js</span>
+        {' if it doesn\'t already exist.'}
+      </p>
+
+      <p>
+        {'The application will not build without a '}
+        <span className={styles.highlight}>project-configs.js</span>
+        {' file in the project root: the boilerplate application relies on the '}
+        <span className={styles.highlight}>PORT</span>
+        {' value being defined as a project configuration variable.'}
+      </p>
+
+      <p>
+        <b>Adding configuration variables</b>
+      </p>
+
+      <p>
+        {'To add a configuration variable, add the variable as a property to '}
+        <span className={styles.highlight}>project-configs.js</span>
+        , in both defined environments:
+      </p>
+
+      <div className={styles.codeBlock}>
+        <CopyButton
+          className={styles.copyButton}
+          textToCopy={configSnippet}
+          colorMode={ColorModes.light}
+        />
+        <p>
+          <span className={styles.grey}>&#47;&#47; project-configs.js</span>
+          <br />
+          <br />
+          module.
+          <span className={styles.darkBlue}>exports =</span>
+          {' {'}
+          <br />
+          &nbsp;&nbsp;
+          <span className={styles.darkBlue}>development</span>
+          {': {'}
+          <br />
+          &nbsp;&nbsp;&nbsp;&nbsp;
+          <span className={styles.darkBlue}>NEW_CONFIG</span>
+          {': '}
+          <span className={styles.darkBlue}>false</span>
+          ,
+          <br />
+          &nbsp;&nbsp;
+          {'},'}
+          <br />
+          &nbsp;&nbsp;
+          <span className={styles.darkBlue}>production</span>
+          {': {'}
+          <br />
+          &nbsp;&nbsp;&nbsp;&nbsp;
+          <span className={styles.darkBlue}>NEW_CONFIG</span>
+          {': '}
+          <span className={styles.darkBlue}>false</span>
+          ,
+          <br />
+          &nbsp;&nbsp;
+          {'},'}
+          <br />
+          {'};'}
+        </p>
+      </div>
+
+      <p>
+        {'Then add a '}
+        <ExternalLink href="https://www.typescriptlang.org/docs/handbook/2/type-declarations.html">
+          type declaration
+        </ExternalLink>
+        {' for the new configuration variable to '}
+        <ExternalLink href="https://github.com/chichiwang/tamsui/blob/main/app/global.d.ts">
+          app/global.d.ts
+        </ExternalLink>
+        :
+      </p>
+
+      <div className={styles.codeBlock}>
+        <CopyButton
+          className={styles.copyButton}
+          textToCopy={declarationSnippet}
+          colorMode={ColorModes.light}
+        />
+        <p>
+          <span className={styles.grey}>&#47;&#47; app/globals.d.ts</span>
+          <br />
+          <br />
+          <span className={styles.red}>declare const</span>
+          {' NEW_CONFIG: '}
+          <span className={styles.orange}>boolean</span>
+          ;
+        </p>
+      </div>
+
+      <p>
+        {'Now '}
+        <span className={styles.highlight}>NEW_CONFIG</span>
+        {' can be used in the project code. When building for development, instances of '}
+        <span className={styles.highlight}>NEW_CONFIG</span>
+        {' will be replaced with '}
+        <span className={styles.highlight}>false</span>
+        {', when building for production instances will be replaced with '}
+        <span className={styles.highlight}>true</span>
+        .
+      </p>
+
+      <p>
+        <b>Note</b>
+        {`: String values must be double-wrapped in quotes, since all config values are
+         passed into the `}
+        <ExternalLink href="https://webpack.js.org/plugins/define-plugin/#usage">
+          DefinePlugin
+        </ExternalLink>
+        {'. This means that string values are treated as code fragments. Calling '}
+        <span className={styles.highlight}>JSON.stringify()</span>
+        {' on string values will also preserve them as strings:'}
+      </p>
+
+      <div className={styles.codeBlock}>
+        <CopyButton
+          className={styles.copyButton}
+          textToCopy={stringsSnippet}
+          colorMode={ColorModes.light}
+        />
+        <p>
+          <span className={styles.grey}>&#47;&#47; project-config.js</span>
+          <br />
+          <br />
+          module.
+          <span className={styles.darkBlue}>exports =</span>
+          {' {'}
+          <br />
+          &nbsp;&nbsp;
+          <span className={styles.darkBlue}>development</span>
+          {': {'}
+          <br />
+          &nbsp;&nbsp;&nbsp;&nbsp;
+          <span className={styles.darkBlue}>DOUBLE_WRAPPED_STRING</span>
+          {': '}
+          <span className={styles.blue}>&quot;&apos;string value&apos;&quot;</span>
+          ,
+          <br />
+          &nbsp;&nbsp;&nbsp;&nbsp;
+          <span className={styles.darkBlue}>JSON_WRAPPED_STRING</span>
+          {': '}
+          <span className={styles.blue}>JSON</span>
+          .
+          <span className={styles.purple}>stringify</span>
+          (
+          <span className={styles.blue}>&apos;remains a string&apos;</span>
+          ),
+          <br />
+          &nbsp;&nbsp;
+          {'},'}
+          <br />
+          &nbsp;&nbsp;
+          <span className={styles.darkBlue}>production</span>
+          {': {'}
+          <br />
+          &nbsp;&nbsp;&nbsp;&nbsp;
+          <span className={styles.grey}>&#47;&#47; ...</span>
+          <br />
+          &nbsp;&nbsp;
+          {'},'}
+          <br />
+          {'};'}
+        </p>
+      </div>
+
+      <p>
+        <b>Testing with configuration variables</b>
+      </p>
+
+      <p>
+        {'New configuration variables can either be mocked into tests by modifying the '}
+        <span className={styles.highlight}>global</span>
+        {' object, or adding the variable to the '}
+        <ExternalLink href="https://jestjs.io/docs/configuration#globals-object">
+          Jest globals object
+        </ExternalLink>
+        {'. The globals object can be added to '}
+        <span className={styles.highlight}>sharedConfigs</span>
+        {', '}
+        <span className={styles.highlight}>appConfig</span>
+        {', '}
+        <span className={styles.highlight}>clientConfig</span>
+        {', or '}
+        <span className={styles.highlight}>serverConfig</span>
+        {' (as appropriate) in '}
+        <ExternalLink href="https://github.com/chichiwang/tamsui/blob/main/jest.config.js">
+          jest.config.js
+        </ExternalLink>
+        .
+      </p>
+    </HeadingBlock>
+  );
+}
+
+export default ProjectConfigurations;

--- a/pages/Documentation/StartingAProject.tsx
+++ b/pages/Documentation/StartingAProject.tsx
@@ -71,6 +71,13 @@ function StartingAProject() {
         <span className={styles.highlight}>npm install</span>
         .
       </ChecklistItem>
+
+      <ChecklistItem>
+        {'Run '}
+        <span className={styles.highlight}>npm run create-config</span>
+        {' to initialize the configuration file '}
+        <span className={styles.highlight}>project-configs.js</span>
+      </ChecklistItem>
     </HeadingBlock>
   );
 }

--- a/pages/Documentation/__tests__/__snapshots__/index.test.js.snap
+++ b/pages/Documentation/__tests__/__snapshots__/index.test.js.snap
@@ -2258,6 +2258,14 @@ exports[`Documentation Page Component matches snapshot 1`] = `
       >
         <li>
           <a
+            href="/#Project-Configurations"
+            onClick={[Function]}
+          >
+            Project Configurations
+          </a>
+        </li>
+        <li>
+          <a
             href="/#Running-the-Application"
             onClick={[Function]}
           >
@@ -2329,6 +2337,607 @@ exports[`Documentation Page Component matches snapshot 1`] = `
           </a>
         </li>
       </ul>
+    </article>
+  </section>
+  <section
+    className="headingBlock"
+  >
+    <div
+      className="container"
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+    >
+      <div
+        className="wrapper"
+      >
+        <h3
+          className="tag"
+          id="Project-Configurations"
+        >
+          Project Configurations
+        </h3>
+        <a
+          aria-labelledby="Project-Configurations"
+          className="link"
+          href="#Project-Configurations"
+        >
+          <svg
+            height="1.75rem"
+            viewBox="0 0 24 24"
+            width="1.75rem"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g
+              fill="none"
+              stroke="currentColor"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2.5}
+            >
+              <path
+                d="M14 11.998C14 9.506 11.683 7 8.857 7H7.143C4.303 7 2 9.238 2 11.998c0 2.378 1.71 4.368 4 4.873a5.3 5.3 0 0 0 1.143.124"
+              />
+              <path
+                d="M10 11.998c0 2.491 2.317 4.997 5.143 4.997h1.714c2.84 0 5.143-2.237 5.143-4.997c0-2.379-1.71-4.37-4-4.874A5.3 5.3 0 0 0 16.857 7"
+              />
+            </g>
+          </svg>
+        </a>
+      </div>
+    </div>
+    <article>
+      <p>
+        <b>
+          Tamsui
+        </b>
+         uses environment-aware configurations via 
+        <a
+          href="https://webpack.js.org/plugins/define-plugin/"
+          rel="noreferrer"
+          target="_blank"
+        >
+          Webpack's DefinePlugin
+        </a>
+        . This behavior is instrumented in 
+        <a
+          href="https://github.com/chichiwang/tamsui/blob/main/webpack/define.js"
+          rel="noreferrer"
+          target="_blank"
+        >
+          webpack/define.js
+        </a>
+        .
+      </p>
+      <p>
+        A sample config file 
+        <span
+          className="highlight"
+        >
+          project-configs-example.js
+        </span>
+         is provided in the project root directory. Running 
+        <span
+          className="highlight"
+        >
+          npm run create-config
+        </span>
+         will copy 
+        <span
+          className="highlight"
+        >
+          project-configs-example.js
+        </span>
+         to 
+        <span
+          className="highlight"
+        >
+          project-configs.js
+        </span>
+         if it doesn't already exist.
+      </p>
+      <p>
+        The application will not build without a 
+        <span
+          className="highlight"
+        >
+          project-configs.js
+        </span>
+         file in the project root: the boilerplate application relies on the 
+        <span
+          className="highlight"
+        >
+          PORT
+        </span>
+         value being defined as a project configuration variable.
+      </p>
+      <p>
+        <b>
+          Adding configuration variables
+        </b>
+      </p>
+      <p>
+        To add a configuration variable, add the variable as a property to 
+        <span
+          className="highlight"
+        >
+          project-configs.js
+        </span>
+        , in both defined environments:
+      </p>
+      <div
+        className="codeBlock"
+      >
+        <div
+          className="copyContainer copyButton"
+        >
+          <div
+            className="copyWrapper lightMode"
+          >
+            <div
+              className="message"
+            >
+              <div
+                className="successMessage"
+              >
+                <span>
+                  Copied!
+                </span>
+              </div>
+              <div
+                className="errorMessage"
+              >
+                <span>
+                  Failed!
+                </span>
+              </div>
+            </div>
+            <button
+              aria-label="Copy text"
+              className="copyButton"
+              onClick={[Function]}
+              type="button"
+            >
+              <svg
+                className="copyIcon"
+                height="1em"
+                viewBox="0 0 24 24"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <g
+                  fill="none"
+                  stroke="currentColor"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                >
+                  <path
+                    d="M7 9.667A2.667 2.667 0 0 1 9.667 7h8.666A2.667 2.667 0 0 1 21 9.667v8.666A2.667 2.667 0 0 1 18.333 21H9.667A2.667 2.667 0 0 1 7 18.333z"
+                  />
+                  <path
+                    d="M4.012 16.737A2 2 0 0 1 3 15V5c0-1.1.9-2 2-2h10c.75 0 1.158.385 1.5 1"
+                  />
+                </g>
+              </svg>
+            </button>
+          </div>
+        </div>
+        <p>
+          <span
+            className="grey"
+          >
+            // project-configs.js
+          </span>
+          <br />
+          <br />
+          module.
+          <span
+            className="darkBlue"
+          >
+            exports =
+          </span>
+           {
+          <br />
+            
+          <span
+            className="darkBlue"
+          >
+            development
+          </span>
+          : {
+          <br />
+              
+          <span
+            className="darkBlue"
+          >
+            NEW_CONFIG
+          </span>
+          : 
+          <span
+            className="darkBlue"
+          >
+            false
+          </span>
+          ,
+          <br />
+            
+          },
+          <br />
+            
+          <span
+            className="darkBlue"
+          >
+            production
+          </span>
+          : {
+          <br />
+              
+          <span
+            className="darkBlue"
+          >
+            NEW_CONFIG
+          </span>
+          : 
+          <span
+            className="darkBlue"
+          >
+            false
+          </span>
+          ,
+          <br />
+            
+          },
+          <br />
+          };
+        </p>
+      </div>
+      <p>
+        Then add a 
+        <a
+          href="https://www.typescriptlang.org/docs/handbook/2/type-declarations.html"
+          rel="noreferrer"
+          target="_blank"
+        >
+          type declaration
+        </a>
+         for the new configuration variable to 
+        <a
+          href="https://github.com/chichiwang/tamsui/blob/main/app/global.d.ts"
+          rel="noreferrer"
+          target="_blank"
+        >
+          app/global.d.ts
+        </a>
+        :
+      </p>
+      <div
+        className="codeBlock"
+      >
+        <div
+          className="copyContainer copyButton"
+        >
+          <div
+            className="copyWrapper lightMode"
+          >
+            <div
+              className="message"
+            >
+              <div
+                className="successMessage"
+              >
+                <span>
+                  Copied!
+                </span>
+              </div>
+              <div
+                className="errorMessage"
+              >
+                <span>
+                  Failed!
+                </span>
+              </div>
+            </div>
+            <button
+              aria-label="Copy text"
+              className="copyButton"
+              onClick={[Function]}
+              type="button"
+            >
+              <svg
+                className="copyIcon"
+                height="1em"
+                viewBox="0 0 24 24"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <g
+                  fill="none"
+                  stroke="currentColor"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                >
+                  <path
+                    d="M7 9.667A2.667 2.667 0 0 1 9.667 7h8.666A2.667 2.667 0 0 1 21 9.667v8.666A2.667 2.667 0 0 1 18.333 21H9.667A2.667 2.667 0 0 1 7 18.333z"
+                  />
+                  <path
+                    d="M4.012 16.737A2 2 0 0 1 3 15V5c0-1.1.9-2 2-2h10c.75 0 1.158.385 1.5 1"
+                  />
+                </g>
+              </svg>
+            </button>
+          </div>
+        </div>
+        <p>
+          <span
+            className="grey"
+          >
+            // app/globals.d.ts
+          </span>
+          <br />
+          <br />
+          <span
+            className="red"
+          >
+            declare const
+          </span>
+           NEW_CONFIG: 
+          <span
+            className="orange"
+          >
+            boolean
+          </span>
+          ;
+        </p>
+      </div>
+      <p>
+        Now 
+        <span
+          className="highlight"
+        >
+          NEW_CONFIG
+        </span>
+         can be used in the project code. When building for development, instances of 
+        <span
+          className="highlight"
+        >
+          NEW_CONFIG
+        </span>
+         will be replaced with 
+        <span
+          className="highlight"
+        >
+          false
+        </span>
+        , when building for production instances will be replaced with 
+        <span
+          className="highlight"
+        >
+          true
+        </span>
+        .
+      </p>
+      <p>
+        <b>
+          Note
+        </b>
+        : String values must be double-wrapped in quotes, since all config values are
+         passed into the 
+        <a
+          href="https://webpack.js.org/plugins/define-plugin/#usage"
+          rel="noreferrer"
+          target="_blank"
+        >
+          DefinePlugin
+        </a>
+        . This means that string values are treated as code fragments. Calling 
+        <span
+          className="highlight"
+        >
+          JSON.stringify()
+        </span>
+         on string values will also preserve them as strings:
+      </p>
+      <div
+        className="codeBlock"
+      >
+        <div
+          className="copyContainer copyButton"
+        >
+          <div
+            className="copyWrapper lightMode"
+          >
+            <div
+              className="message"
+            >
+              <div
+                className="successMessage"
+              >
+                <span>
+                  Copied!
+                </span>
+              </div>
+              <div
+                className="errorMessage"
+              >
+                <span>
+                  Failed!
+                </span>
+              </div>
+            </div>
+            <button
+              aria-label="Copy text"
+              className="copyButton"
+              onClick={[Function]}
+              type="button"
+            >
+              <svg
+                className="copyIcon"
+                height="1em"
+                viewBox="0 0 24 24"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <g
+                  fill="none"
+                  stroke="currentColor"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                >
+                  <path
+                    d="M7 9.667A2.667 2.667 0 0 1 9.667 7h8.666A2.667 2.667 0 0 1 21 9.667v8.666A2.667 2.667 0 0 1 18.333 21H9.667A2.667 2.667 0 0 1 7 18.333z"
+                  />
+                  <path
+                    d="M4.012 16.737A2 2 0 0 1 3 15V5c0-1.1.9-2 2-2h10c.75 0 1.158.385 1.5 1"
+                  />
+                </g>
+              </svg>
+            </button>
+          </div>
+        </div>
+        <p>
+          <span
+            className="grey"
+          >
+            // project-config.js
+          </span>
+          <br />
+          <br />
+          module.
+          <span
+            className="darkBlue"
+          >
+            exports =
+          </span>
+           {
+          <br />
+            
+          <span
+            className="darkBlue"
+          >
+            development
+          </span>
+          : {
+          <br />
+              
+          <span
+            className="darkBlue"
+          >
+            DOUBLE_WRAPPED_STRING
+          </span>
+          : 
+          <span
+            className="blue"
+          >
+            "'string value'"
+          </span>
+          ,
+          <br />
+              
+          <span
+            className="darkBlue"
+          >
+            JSON_WRAPPED_STRING
+          </span>
+          : 
+          <span
+            className="blue"
+          >
+            JSON
+          </span>
+          .
+          <span
+            className="purple"
+          >
+            stringify
+          </span>
+          (
+          <span
+            className="blue"
+          >
+            'remains a string'
+          </span>
+          ),
+          <br />
+            
+          },
+          <br />
+            
+          <span
+            className="darkBlue"
+          >
+            production
+          </span>
+          : {
+          <br />
+              
+          <span
+            className="grey"
+          >
+            // ...
+          </span>
+          <br />
+            
+          },
+          <br />
+          };
+        </p>
+      </div>
+      <p>
+        <b>
+          Testing with configuration variables
+        </b>
+      </p>
+      <p>
+        New configuration variables can either be mocked into tests by modifying the 
+        <span
+          className="highlight"
+        >
+          global
+        </span>
+         object, or adding the variable to the 
+        <a
+          href="https://jestjs.io/docs/configuration#globals-object"
+          rel="noreferrer"
+          target="_blank"
+        >
+          Jest globals object
+        </a>
+        . The globals object can be added to 
+        <span
+          className="highlight"
+        >
+          sharedConfigs
+        </span>
+        , 
+        <span
+          className="highlight"
+        >
+          appConfig
+        </span>
+        , 
+        <span
+          className="highlight"
+        >
+          clientConfig
+        </span>
+        , or 
+        <span
+          className="highlight"
+        >
+          serverConfig
+        </span>
+         (as appropriate) in 
+        <a
+          href="https://github.com/chichiwang/tamsui/blob/main/jest.config.js"
+          rel="noreferrer"
+          target="_blank"
+        >
+          jest.config.js
+        </a>
+        .
+      </p>
     </article>
   </section>
   <section

--- a/pages/Documentation/__tests__/__snapshots__/index.test.js.snap
+++ b/pages/Documentation/__tests__/__snapshots__/index.test.js.snap
@@ -718,6 +718,62 @@ exports[`Documentation Page Component matches snapshot 1`] = `
           </span>
         </label>
       </div>
+      <div
+        className="checklistItem"
+      >
+        <label>
+          <input
+            checked={false}
+            className="checkboxInput"
+            onChange={[Function]}
+            type="checkbox"
+          />
+          <div
+            className="checkboxContainer"
+          >
+            <div
+              className="checkbox"
+            >
+              <div
+                className="top"
+              >
+                <div
+                  className="back"
+                />
+                <div
+                  className="front"
+                />
+              </div>
+              <div
+                className="bottom"
+              >
+                <div
+                  className="back"
+                />
+                <div
+                  className="front"
+                />
+              </div>
+            </div>
+          </div>
+          <span
+            className="labelContent"
+          >
+            Run 
+            <span
+              className="highlight"
+            >
+              npm run create-config
+            </span>
+             to initialize the configuration file 
+            <span
+              className="highlight"
+            >
+              project-configs.js
+            </span>
+          </span>
+        </label>
+      </div>
     </article>
   </section>
   <section
@@ -1431,6 +1487,91 @@ exports[`Documentation Page Component matches snapshot 1`] = `
                   dist/
                 </span>
                  directory
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <div
+                className="script"
+              >
+                <span
+                  className="highlight"
+                >
+                  create-config
+                </span>
+                <div
+                  className="copyContainer copyButton"
+                >
+                  <div
+                    className="copyWrapper"
+                  >
+                    <div
+                      className="message"
+                    >
+                      <div
+                        className="successMessage"
+                      >
+                        <span>
+                          Copied!
+                        </span>
+                      </div>
+                      <div
+                        className="errorMessage"
+                      >
+                        <span>
+                          Failed!
+                        </span>
+                      </div>
+                    </div>
+                    <button
+                      aria-label="Copy text"
+                      className="copyButton"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <svg
+                        className="copyIcon"
+                        height="1em"
+                        viewBox="0 0 24 24"
+                        width="1em"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <g
+                          fill="none"
+                          stroke="currentColor"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={2}
+                        >
+                          <path
+                            d="M7 9.667A2.667 2.667 0 0 1 9.667 7h8.666A2.667 2.667 0 0 1 21 9.667v8.666A2.667 2.667 0 0 1 18.333 21H9.667A2.667 2.667 0 0 1 7 18.333z"
+                          />
+                          <path
+                            d="M4.012 16.737A2 2 0 0 1 3 15V5c0-1.1.9-2 2-2h10c.75 0 1.158.385 1.5 1"
+                          />
+                        </g>
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </td>
+            <td>
+              <p>
+                Copies 
+                <span
+                  className="highlight"
+                >
+                  project-configs-example.js
+                </span>
+                 to 
+                <span
+                  className="highlight"
+                >
+                  project-configs.js
+                </span>
+                 in the root directory only if it doesn't already exist
               </p>
             </td>
           </tr>

--- a/pages/Documentation/index.tsx
+++ b/pages/Documentation/index.tsx
@@ -8,6 +8,7 @@ import InternalLink from 'app/components/InternalLink';
 
 import StartingAProject from './StartingAProject';
 import NPMScripts from './NPMScripts';
+import ProjectConfigurations from './ProjectConfigurations';
 import RunningTheApplication from './RunningTheApplication';
 import ProjectDirectories from './ProjectDirectories';
 import AddingAnApplicationDirectory from './AddingAnApplicationDirectory';
@@ -66,6 +67,9 @@ function Documentation() {
       >
         <ul className={classNames(styles.list, styles.content)}>
           <li>
+            <InternalLink to="#Project-Configurations">Project Configurations</InternalLink>
+          </li>
+          <li>
             <InternalLink to="#Running-the-Application">Running the Application</InternalLink>
           </li>
           <li>
@@ -95,6 +99,7 @@ function Documentation() {
         </ul>
       </HeadingBlock>
 
+      <ProjectConfigurations />
       <RunningTheApplication />
       <ProjectDirectories />
       <AddingAnApplicationDirectory />

--- a/project-configs-example.js
+++ b/project-configs-example.js
@@ -1,0 +1,8 @@
+module.exports = {
+  development: {
+    PORT: 8080,
+  },
+  production: {
+    PORT: 3000,
+  },
+};

--- a/server/__tests__/index.test.js
+++ b/server/__tests__/index.test.js
@@ -24,10 +24,13 @@ function mockExpressStatic(path) {
   return `Static Asset Directory: ${path}`;
 }
 
+const mockedPORT = 8080;
+
 describe('server', () => {
   beforeAll(() => {
     express.mockReturnValue(mockExpressApp);
     express.static.mockImplementation(mockExpressStatic);
+    global.PORT = mockedPORT;
   });
 
   beforeEach(() => {
@@ -35,6 +38,10 @@ describe('server', () => {
     jest.isolateModules(() => {
       require('../index');
     });
+  });
+
+  afterAll(() => {
+    delete global.PORT;
   });
 
   test('express is invoked once', () => {
@@ -45,8 +52,8 @@ describe('server', () => {
     expect(mockAppListen).toHaveBeenCalledTimes(1);
   });
 
-  test('app.listen is called with port 8080', () => {
-    expect(mockAppListen).toHaveBeenCalledWith(8080, expect.any(Function));
+  test('app.listen is called with port value', () => {
+    expect(mockAppListen).toHaveBeenCalledWith(expect.any(Number), expect.any(Function));
   });
 
   test('app.listen is passed a callback that logs out the port the app is listening on', () => {

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,3 +1,4 @@
+/* global PORT */
 import path from 'node:path';
 
 import express, {
@@ -9,7 +10,7 @@ import httpLogger from './httpLogger';
 import appHandler from './appHandler';
 
 const app: Express = express();
-const port: Number = 8080;
+const port: Number = PORT;
 
 app.use(httpLogger);
 app.use('/scripts', express.static(path.resolve(__dirname, 'scripts')));

--- a/webpack/client.config.js
+++ b/webpack/client.config.js
@@ -8,6 +8,7 @@ const env = require('./env');
 const typescriptRule = require('./rules/typescript');
 const sassModulesRule = require('./rules/sass.modules');
 const resolve = require('./resolve');
+const define = require('./define');
 
 const config = {
   mode: env.get(),
@@ -47,6 +48,7 @@ const config = {
     new WebpackManifestPlugin({
       publicPath: '',
     }),
+    define,
   ],
   resolve,
 };

--- a/webpack/define.js
+++ b/webpack/define.js
@@ -5,6 +5,7 @@ const env = require('./env');
 let configs;
 
 try {
+  /* eslint-disable-next-line import/extensions, import/no-unresolved */
   configs = require('../project-configs');
 } catch (_) {
   throw new Error('Missing project-configs.js in project root! Run `npm create-config` to initialize.');

--- a/webpack/define.js
+++ b/webpack/define.js
@@ -1,0 +1,15 @@
+/* eslint-disable global-require, import/no-extraneous-dependencies */
+const webpack = require('webpack');
+const env = require('./env');
+
+let configs;
+
+try {
+  configs = require('../project-configs');
+} catch (_) {
+  throw new Error('Missing project-configs.js in project root! Run `npm create-config` to initialize.');
+}
+
+module.exports = new webpack.DefinePlugin({
+  ...(configs[env.get()]),
+});

--- a/webpack/server.config.js
+++ b/webpack/server.config.js
@@ -8,6 +8,7 @@ const env = require('./env');
 const typescriptRule = require('./rules/typescript');
 const sassInlineRule = require('./rules/sass.inline');
 const resolve = require('./resolve');
+const define = require('./define');
 
 const config = {
   mode: env.get(),
@@ -38,6 +39,7 @@ const config = {
       ],
       ignore: ['/__tests__/', '**.test.*'],
     })]),
+    define,
   ],
   resolve,
 };


### PR DESCRIPTION
## Description
Linked to Issue: #125
Create a configuration file for the project `project-configs.js` which is git-ignored (configurations can be project-specific and should not be tracked in the case they either contain business logic to retrieve or secrets).

A sample file to show the format, `project-configs-example.js` is added to the project to serve as example for the structure expected of the configurations. A npm script `create-config` is added to copy `project-configs-example.js` to a new file `project-configs.js` only if that file does not already exist.

These configurations are fed into the build step via [Webpack DefinePlugin](https://webpack.js.org/plugins/define-plugin/) and gated against production vs non-production build environments: the `development` configs will be used for non-production builds, and the `production` configs used for production builds.

The first config value, `PORT` is added to set the server port to `8080` for non-production builds and `3000` for production builds. `server/index.ts` is updated to use this configuration via the Webpack global `PORT`.

Documentation is updated in both `docs/README.md` and `pages/Documentation/index.tsx` to:
* Add a step to run `npm run create-config` in the section "Starting a Project"
* Add documentation for the script `create-config` in the section "NPM Scripts"
* Add a section under "Developing Locally" called "Project Configurations" to outline how project configurations work, and how to add one

## Changes
* Add "project-configs.js" to `.gitignore`
* Increase `p` tag `line-height` to `1.75rem` in `app/global.module.scss`
* Declare a constant `PORT` in `app/globals.d.ts`
* Update `docs/README.md`
  * Add step to section: Starting a Project
  * Add documentation for script `create-config` in section: NPM Scripts
  * Add section: Project Configurations
* Add script `create-config` to `package.json`
  * Copy `project-configs-example.js` to a new file `project-configs.js` if it does not already exist
* Update `pages/Documentation/NPMScripts.tsx` to add documentation for script `create-config`
* Create a `pages/Documentation/ProjectConfigurations.tsx` to document project configuration
  * Mirrors content in `docs/README.md` in the section: Project Configurations
* Update `pages/Documentation/StartingAProject.tsx`
  * Add a step to run `npm run create-config`
* Update `pages/Documentation/index.tsx`
  * Render section: Project Configurations
  * Create link in "Developing Locally" to link to section: Project Configurations
* Add a `project-configs-example.js` file with a sample project config
* Update `server/index.ts` to read the port from the project config variable `PORT`
  * Update tests
* Create a `webpack/define.js` module to feed project config into the Webpack DefinePlugin based on build environment
  * Plug this plugin instance into `webpack/client.config.js` and `webpack/server.config.js`

## Steps to QA
* Pull down and switch to this branch
* Without generating a `project-configs.js` file:
  * Run `npm run watch`, `npm run dev`, `npm run prod`, or any of the build scripts to ensure they fail with a meaningful error message
  * Run `npm run create-config` to ensure that a `project-configs.js` file is generated and its contents match `project-configs-example.js`
* After having generated a `project-configs.js` file:
  *  Make a change to the file
    * Run `npm run create-config` and ensure the contents of that file have not changed
    * Ensure the change is not picked up by git (`git status`)
* Run the app in development mode (`npm run watch`/`npm run dev`) and ensure the server is listening on the port specified for development in `project-config.js`
* Run the app in production mode (`npm run prod`) and ensure the server is listening on the port specified for production in `project-config.js`
* Review the changes in `docs/README.md` to make sure they read well
* Run the app and review the changes on the `/documentation` page to ensure they look correct
  * Check the contents of the copy button in the sections "NPM Scripts" and "Project Configurations" to ensure they are correct
