### PR TITLE
Create project config `SERVE_STATIC` to guard static asset serving

### DIFF
--- a/app/globals.d.ts
+++ b/app/globals.d.ts
@@ -1,3 +1,4 @@
 declare module '*.module.scss';
 
 declare const PORT: number;
+declare const SERVE_STATIC: boolean;

--- a/project-configs-example.js
+++ b/project-configs-example.js
@@ -1,8 +1,10 @@
 module.exports = {
   development: {
     PORT: 8080,
+    SERVE_STATIC: true,
   },
   production: {
     PORT: 3000,
+    SERVE_STATIC: true,
   },
 };

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,4 +1,4 @@
-/* global PORT */
+/* global PORT, SERVE_STATIC */
 import path from 'node:path';
 
 import express, {
@@ -13,9 +13,12 @@ const app: Express = express();
 const port: Number = PORT;
 
 app.use(httpLogger);
-app.use('/scripts', express.static(path.resolve(__dirname, 'scripts')));
-app.use('/styles', express.static(path.resolve(__dirname, 'styles')));
-app.use('/static', express.static(path.resolve(__dirname, 'static')));
+
+if (SERVE_STATIC) {
+  app.use('/scripts', express.static(path.resolve(__dirname, 'scripts')));
+  app.use('/styles', express.static(path.resolve(__dirname, 'styles')));
+  app.use('/static', express.static(path.resolve(__dirname, 'static')));
+}
 
 app.get('*', appHandler);
 


### PR DESCRIPTION
## Description
Linked to Issue: #127 
Create a project config `SERVE_STATIC` per environment. The Express server is now set up to check the value (boolean) of `SERVE_STATIC` during build to determine if static asset directories should be served by the express server.

The purpose of this is to allow the developer to determine if static assets should be served via CDN vs the backend Express server.

## Changes
* Declare a type for `SERVE_STATIC` in `app/globals.d.ts`
* Set project config `SERVE_STATIC` to `true` for `development` builds and `false` for `production` builds in `project-configs-example.js`
* Guard against using `express.static` middleware based on the value of project config `SERVE_STATIC` in `server/index.ts`

## Steps to QA
* Pull down and switch to this branch
* Set `SERVE_STATIC` in local `project-configs` to `true` for development/production
* Run the app and verify in browser:
  * Static assets are being served by the local app server
* Set `SERVE_STATIC` in local `project-configs` to `false` for development/production and verify in browser
  * Static assets are not served by the local app server - 404 errors
