### PR TITLE
HeroBanner: Smoother Animations, CSS Adjustments - Behind main branch

### DIFF
--- a/pages/components/HeroBanner/SceneMaroon/styles.cloudscapebackground.module.scss
+++ b/pages/components/HeroBanner/SceneMaroon/styles.cloudscapebackground.module.scss
@@ -21,6 +21,11 @@ $gap-height: 3px;
       left: -2875px;
     }
 
+    & > div {
+      transform: translate3d(0, 0, 0);
+      will-change: transform;
+    }
+
     .cloud01 {
       position: absolute;
       top: 55px;
@@ -246,6 +251,7 @@ $gap-height: 3px;
   animation-duration: 500s;
   animation-name: float-background;
   animation-timing-function: linear;
+  will-change: transform;
 
   @media print {
     animation: none;
@@ -254,10 +260,10 @@ $gap-height: 3px;
 
 @keyframes float-background {
   0% {
-    left: 0px;
+    transform: translate3d(0px, 0, 0);
   }
 
   100% {
-    left: 1920px;
+    transform: translate3d(1920px, 0, 0);
   }
 }

--- a/pages/components/HeroBanner/SceneOrange/styles.cloudscapeforeground.module.scss
+++ b/pages/components/HeroBanner/SceneOrange/styles.cloudscapeforeground.module.scss
@@ -21,6 +21,11 @@ $gap-height: 3px;
       left: -2875px;
     }
 
+    & > div {
+      transform: translate3d(0, 0, 0);
+      will-change: transform;
+    }
+
     .cloud01 {
       position: absolute;
       top: 235px;
@@ -270,8 +275,8 @@ $gap-height: 3px;
           content: '';
           position: absolute;
           top: 73%;
-          left: -19%;
-          width: 152%;
+          left: -30%;
+          width: 160%;
           height: 60%;
           background-color: map.get(var.$colors, 'orange');
           border-top-right-radius: 15% 80%;
@@ -330,6 +335,7 @@ $gap-height: 3px;
   animation-duration: 350s;
   animation-name: float-foreground;
   animation-timing-function: linear;
+  will-change: transform;
 
   @media print {
     animation: none;
@@ -338,10 +344,10 @@ $gap-height: 3px;
 
 @keyframes float-foreground {
   0% {
-    left: 0px;
+    transform: translate3d(0px, 0, 0);
   }
 
   100% {
-    left: 1920px;
+    transform: translate3d(1920px, 0, 0);
   }
 }

--- a/pages/components/HeroBanner/styles.module.scss
+++ b/pages/components/HeroBanner/styles.module.scss
@@ -39,7 +39,7 @@ $gap-height: 6px;
 
   .hexBackdrop {
     position: absolute;
-    top: 250px;
+    top: 251px;
     left: 50%;
     height: 108px;
     width: 184px;


### PR DESCRIPTION
## Description
Linked to Issue: N/A
On high resolution screens, the cloud animations in the `HeroBanner` are a bit overly jittery. This is fixed by engaging GPU acceleration (by setting a `translate3d` value) and by setting the [will-change](https://developer.mozilla.org/en-US/docs/Web/CSS/will-change) property on our moving scenes. Animations are now set to change the `transform` property using `translate3d` rather than `left`.

This PR also adjusts the outline on the animated logo in the `HeroBanner` so that it is better vertically centered.

## Changes
* Smooth out the animation in `pages/components/HeroBanner/SceneMaroon/styles.cloudscapebackground.module.scss`
* Smooth out the animation in `pages/components/HeroBanner/SceneOrange/styles.cloudscapeforeground.module.scss`
* Tweak the vertical centering of the hex backdrop in `pages/components/HeroBanner/styles.module.scss`

## Steps to QA
* Pull down and switch to this branch
* Run this branch locally and verify on a high resolution monitor (> 1922px) in browser that the animations in the Hero Banner on `/` are smoother than on the `main` branch
