### PR TITLE
useResetScroll: Drive focus on hash-link navigation

### DIFF
--- a/app/components/Heading/__tests__/__snapshots__/index.test.js.snap
+++ b/app/components/Heading/__tests__/__snapshots__/index.test.js.snap
@@ -43,7 +43,6 @@ exports[`Heading component matches id snapshot 1`] = `
   >
     <h2
       className="tag"
-      id="FooBaz"
     >
       H2 Heading with ID
     </h2>
@@ -51,6 +50,7 @@ exports[`Heading component matches id snapshot 1`] = `
       aria-labelledby="FooBaz"
       className="link"
       href="#FooBaz"
+      id="FooBaz"
     >
       <svg
         height="1.75rem"

--- a/app/components/Heading/index.tsx
+++ b/app/components/Heading/index.tsx
@@ -51,7 +51,6 @@ function Heading({
           React.createElement(
             `h${level}`,
             {
-              ...(typeof id === 'undefined' ? {} : { id }),
               className: classNames(
                 styles.tag,
                 className,
@@ -64,7 +63,7 @@ function Heading({
           typeof id === 'undefined'
             ? null
             : (
-              <a className={styles.link} href={`#${id}`} aria-labelledby={id}>
+              <a id={id} className={styles.link} href={`#${id}`} aria-labelledby={id}>
                 <LinkIcon width="1.75rem" height="1.75rem" />
               </a>
             )

--- a/app/hooks/__tests__/useResetScroll.test.js
+++ b/app/hooks/__tests__/useResetScroll.test.js
@@ -23,6 +23,7 @@ const mockedLocation = {
 const mockedScrollTo = jest.fn();
 const mockedElement = {
   scrollIntoView: jest.fn(),
+  focus: jest.fn(),
 };
 
 describe('useResetScroll', () => {
@@ -154,6 +155,17 @@ describe('useResetScroll', () => {
           .toHaveBeenCalledWith(pathWithHash, expect.objectContaining({
             replace: true,
           }));
+      });
+
+      test('handler sets focus on the element with the same id as the hash', () => {
+        global.document.getElementById.mockReturnValueOnce(mockedElement);
+
+        useResetScroll();
+
+        const [effectHandler] = useLayoutEffect.mock.calls[0];
+        effectHandler();
+
+        expect(mockedElement.focus).toHaveBeenCalledTimes(1);
       });
 
       test('handler scrolls to top of page if no element has id that matches hash', () => {

--- a/app/hooks/useResetScroll.ts
+++ b/app/hooks/useResetScroll.ts
@@ -13,6 +13,7 @@ function useResetScroll() {
       const $hashEl = document.getElementById(IdFromHash);
 
       if ($hashEl) {
+        $hashEl.focus();
         $hashEl.scrollIntoView(true);
       } else {
         document.documentElement.scrollTo({

--- a/pages/Documentation/__tests__/__snapshots__/index.test.js.snap
+++ b/pages/Documentation/__tests__/__snapshots__/index.test.js.snap
@@ -110,7 +110,6 @@ exports[`Documentation Page Component matches snapshot 1`] = `
       >
         <h2
           className="tag"
-          id="Starting-a-Project"
         >
           Starting a Project
         </h2>
@@ -118,6 +117,7 @@ exports[`Documentation Page Component matches snapshot 1`] = `
           aria-labelledby="Starting-a-Project"
           className="link"
           href="#Starting-a-Project"
+          id="Starting-a-Project"
         >
           <svg
             height="1.75rem"
@@ -733,7 +733,6 @@ exports[`Documentation Page Component matches snapshot 1`] = `
       >
         <h2
           className="tag"
-          id="NPM-Scripts"
         >
           NPM Scripts
         </h2>
@@ -741,6 +740,7 @@ exports[`Documentation Page Component matches snapshot 1`] = `
           aria-labelledby="NPM-Scripts"
           className="link"
           href="#NPM-Scripts"
+          id="NPM-Scripts"
         >
           <svg
             height="1.75rem"
@@ -2078,7 +2078,6 @@ exports[`Documentation Page Component matches snapshot 1`] = `
       >
         <h2
           className="tag"
-          id="Developing-Locally"
         >
           Developing Locally
         </h2>
@@ -2086,6 +2085,7 @@ exports[`Documentation Page Component matches snapshot 1`] = `
           aria-labelledby="Developing-Locally"
           className="link"
           href="#Developing-Locally"
+          id="Developing-Locally"
         >
           <svg
             height="1.75rem"
@@ -2211,7 +2211,6 @@ exports[`Documentation Page Component matches snapshot 1`] = `
       >
         <h3
           className="tag"
-          id="Project-Configurations"
         >
           Project Configurations
         </h3>
@@ -2219,6 +2218,7 @@ exports[`Documentation Page Component matches snapshot 1`] = `
           aria-labelledby="Project-Configurations"
           className="link"
           href="#Project-Configurations"
+          id="Project-Configurations"
         >
           <svg
             height="1.75rem"
@@ -2933,7 +2933,6 @@ exports[`Documentation Page Component matches snapshot 1`] = `
       >
         <h3
           className="tag"
-          id="Running-the-Application"
         >
           Running the Application
         </h3>
@@ -2941,6 +2940,7 @@ exports[`Documentation Page Component matches snapshot 1`] = `
           aria-labelledby="Running-the-Application"
           className="link"
           href="#Running-the-Application"
+          id="Running-the-Application"
         >
           <svg
             height="1.75rem"
@@ -3014,7 +3014,6 @@ exports[`Documentation Page Component matches snapshot 1`] = `
       >
         <h3
           className="tag"
-          id="Project-Directories"
         >
           Project Directories
         </h3>
@@ -3022,6 +3021,7 @@ exports[`Documentation Page Component matches snapshot 1`] = `
           aria-labelledby="Project-Directories"
           className="link"
           href="#Project-Directories"
+          id="Project-Directories"
         >
           <svg
             height="1.75rem"
@@ -3159,7 +3159,6 @@ exports[`Documentation Page Component matches snapshot 1`] = `
       >
         <h3
           className="tag"
-          id="Adding-an-Application-Directory"
         >
           Adding an Application Directory
         </h3>
@@ -3167,6 +3166,7 @@ exports[`Documentation Page Component matches snapshot 1`] = `
           aria-labelledby="Adding-an-Application-Directory"
           className="link"
           href="#Adding-an-Application-Directory"
+          id="Adding-an-Application-Directory"
         >
           <svg
             height="1.75rem"
@@ -3421,7 +3421,6 @@ exports[`Documentation Page Component matches snapshot 1`] = `
       >
         <h3
           className="tag"
-          id="Static-Files"
         >
           Static Files
         </h3>
@@ -3429,6 +3428,7 @@ exports[`Documentation Page Component matches snapshot 1`] = `
           aria-labelledby="Static-Files"
           className="link"
           href="#Static-Files"
+          id="Static-Files"
         >
           <svg
             height="1.75rem"
@@ -3566,7 +3566,6 @@ exports[`Documentation Page Component matches snapshot 1`] = `
       >
         <h3
           className="tag"
-          id="Error-Boundary"
         >
           Error Boundary
         </h3>
@@ -3574,6 +3573,7 @@ exports[`Documentation Page Component matches snapshot 1`] = `
           aria-labelledby="Error-Boundary"
           className="link"
           href="#Error-Boundary"
+          id="Error-Boundary"
         >
           <svg
             height="1.75rem"
@@ -3908,7 +3908,6 @@ exports[`Documentation Page Component matches snapshot 1`] = `
       >
         <h3
           className="tag"
-          id="Testing"
         >
           Testing
         </h3>
@@ -3916,6 +3915,7 @@ exports[`Documentation Page Component matches snapshot 1`] = `
           aria-labelledby="Testing"
           className="link"
           href="#Testing"
+          id="Testing"
         >
           <svg
             height="1.75rem"
@@ -4042,7 +4042,6 @@ exports[`Documentation Page Component matches snapshot 1`] = `
       >
         <h3
           className="tag"
-          id="Application-Layouts"
         >
           Application Layouts
         </h3>
@@ -4050,6 +4049,7 @@ exports[`Documentation Page Component matches snapshot 1`] = `
           aria-labelledby="Application-Layouts"
           className="link"
           href="#Application-Layouts"
+          id="Application-Layouts"
         >
           <svg
             height="1.75rem"
@@ -4423,7 +4423,6 @@ exports[`Documentation Page Component matches snapshot 1`] = `
       >
         <h3
           className="tag"
-          id="Pull-Request-Template"
         >
           Pull Request Template
         </h3>
@@ -4431,6 +4430,7 @@ exports[`Documentation Page Component matches snapshot 1`] = `
           aria-labelledby="Pull-Request-Template"
           className="link"
           href="#Pull-Request-Template"
+          id="Pull-Request-Template"
         >
           <svg
             height="1.75rem"
@@ -4550,7 +4550,6 @@ exports[`Documentation Page Component matches snapshot 1`] = `
       >
         <h3
           className="tag"
-          id="Github-Workflow"
         >
           Github Workflow
         </h3>
@@ -4558,6 +4557,7 @@ exports[`Documentation Page Component matches snapshot 1`] = `
           aria-labelledby="Github-Workflow"
           className="link"
           href="#Github-Workflow"
+          id="Github-Workflow"
         >
           <svg
             height="1.75rem"
@@ -4635,7 +4635,6 @@ exports[`Documentation Page Component matches snapshot 1`] = `
       >
         <h2
           className="tag"
-          id="Building-for-Production"
         >
           Building for Production
         </h2>
@@ -4643,6 +4642,7 @@ exports[`Documentation Page Component matches snapshot 1`] = `
           aria-labelledby="Building-for-Production"
           className="link"
           href="#Building-for-Production"
+          id="Building-for-Production"
         >
           <svg
             height="1.75rem"

--- a/pages/Home/__tests__/__snapshots__/index.test.js.snap
+++ b/pages/Home/__tests__/__snapshots__/index.test.js.snap
@@ -731,7 +731,6 @@ exports[`Home Component matches snapshot 1`] = `
         >
           <h2
             className="tag"
-            id="Mission-Intent"
           >
             Mission Intent
           </h2>
@@ -739,6 +738,7 @@ exports[`Home Component matches snapshot 1`] = `
             aria-labelledby="Mission-Intent"
             className="link"
             href="#Mission-Intent"
+            id="Mission-Intent"
           >
             <svg
               height="1.75rem"
@@ -818,7 +818,6 @@ exports[`Home Component matches snapshot 1`] = `
         >
           <h3
             className="tag"
-            id="What-Tamsui-Is-Not"
           >
             What Tamsui Is Not
           </h3>
@@ -826,6 +825,7 @@ exports[`Home Component matches snapshot 1`] = `
             aria-labelledby="What-Tamsui-Is-Not"
             className="link"
             href="#What-Tamsui-Is-Not"
+            id="What-Tamsui-Is-Not"
           >
             <svg
               height="1.75rem"
@@ -899,7 +899,6 @@ exports[`Home Component matches snapshot 1`] = `
         >
           <h2
             className="tag"
-            id="Tech-Stack"
           >
             Tech Stack
           </h2>
@@ -907,6 +906,7 @@ exports[`Home Component matches snapshot 1`] = `
             aria-labelledby="Tech-Stack"
             className="link"
             href="#Tech-Stack"
+            id="Tech-Stack"
           >
             <svg
               height="1.75rem"
@@ -1145,7 +1145,6 @@ exports[`Home Component matches snapshot 1`] = `
         >
           <h2
             className="tag"
-            id="Usage"
           >
             Usage
           </h2>
@@ -1153,6 +1152,7 @@ exports[`Home Component matches snapshot 1`] = `
             aria-labelledby="Usage"
             className="link"
             href="#Usage"
+            id="Usage"
           >
             <svg
               height="1.75rem"


### PR DESCRIPTION
## Description
Linked to Issue: #129 
When using keyboard navigation, following a link with a hash does not drive focus to that section of the page. This PR fixes this by driving focus to the element with the `id` attribute that matches the link hash.

Since heading tags are not normally tab-focusable, the `Heading` component has been updated to place the `id` attribute on the anchor tag instead.

## Changes
* Move the `id` attribute from the heading tag to the anchor tag in `app/components/Heading/index.tsx`
* Drive focus to the element with an `id` attribute matching the hash link in `app/hooks/useResetScroll.ts`

## Steps to QA
* Pull down and switch to this branch
* Verify in browser:
  * From the `/documentation` page, follow a hash link using keyboard navigation. Focus should jump to the linked section when a link is followed.
  * Add a hash-link to a section of `/documentation` (ex: `/documentation#Project-Configurations`) to the home page. Following this link should drive focus to that section upon navigation.