### PR TITLE
Home page: Lowercase final word of the tag line

### DIFF
--- a/pages/Home/__tests__/__snapshots__/index.test.js.snap
+++ b/pages/Home/__tests__/__snapshots__/index.test.js.snap
@@ -652,7 +652,7 @@ exports[`Home Component matches snapshot 1`] = `
         <p
           className="tagline"
         >
-          An Express / TypeScript / React server-side rendered universal JavaScript application Boilerplate
+          An Express / TypeScript / React server-side rendered universal JavaScript application boilerplate
         </p>
         <p>
           Tamsui is a 

--- a/pages/Home/index.tsx
+++ b/pages/Home/index.tsx
@@ -17,7 +17,7 @@ function Home(): React.ReactElement {
         <HeadingBlock level="1" heading="Tamsui" center>
           <p className={styles.tagline}>
             An Express / TypeScript / React server-side rendered
-            universal JavaScript application Boilerplate
+            universal JavaScript application boilerplate
           </p>
 
           <p>


### PR DESCRIPTION
## Description
Linked to Issue: N/A
Lowercase the final word of the tag line since it looks weird for "Boilerplate" to be capitalized.

## Changes
* Lowercase the final word of the tag line in `pages/Home/index.tsx`

## Steps to QA
* Pull down and switch to this branch
* Run the app and verify in browser the last word of the tagline on `/` is lowercased
