### PR TITLE
Create context: ManifestContext

### DIFF
--- a/app/App/index.tsx
+++ b/app/App/index.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { Manifest } from 'app/types';
 
+import ManifestContext from 'app/context/ManifestContext';
+
 import 'app/global.module.scss';
 
 type AppProps = React.PropsWithChildren<{
@@ -10,28 +12,30 @@ type AppProps = React.PropsWithChildren<{
 export default function App({ manifest, children }: AppProps): React.ReactElement {
   return (
     <React.StrictMode>
-      <html lang="en">
-        <head>
-          <meta charSet="utf-8" />
-          <title>Tamsui: A Universal JavaScript Application Boilerplate</title>
-          <meta name="author" content="Chi-chi Wang" />
-          <meta
-            name="keywords"
-            content="Tamsui, js, JavaScript, isomorphic, Node.js, React, TypeScript, Express, React-Router, Boilerplate"
-          />
-          <meta name="description" content="An Express/React universal application boilerplate" />
-          <meta name="robots" content="all" />
-          <meta name="viewport" content="width=device-width" />
-          <link rel="stylesheet" type="text/css" href={`/${manifest['app.css']}`} />
-          <link rel="apple-touch-icon" sizes="180x180" href="/static/images/favicon/apple-touch-icon.png" />
-          <link rel="icon" type="image/png" sizes="32x32" href="/static/images/favicon/favicon-32x32.png" />
-          <link rel="icon" type="image/png" sizes="16x16" href="/static/images/favicon/favicon-16x16.png" />
-          <link rel="manifest" href="/static/site.webmanifest" />
-        </head>
-        <body>
-          { children }
-        </body>
-      </html>
+      <ManifestContext.Provider value={manifest}>
+        <html lang="en">
+          <head>
+            <meta charSet="utf-8" />
+            <title>Tamsui: A Universal JavaScript Application Boilerplate</title>
+            <meta name="author" content="Chi-chi Wang" />
+            <meta
+              name="keywords"
+              content="Tamsui, js, JavaScript, isomorphic, Node.js, React, TypeScript, Express, React-Router, Boilerplate"
+            />
+            <meta name="description" content="An Express/React universal application boilerplate" />
+            <meta name="robots" content="all" />
+            <meta name="viewport" content="width=device-width" />
+            <link rel="stylesheet" type="text/css" href={`/${manifest['app.css']}`} />
+            <link rel="apple-touch-icon" sizes="180x180" href="/static/images/favicon/apple-touch-icon.png" />
+            <link rel="icon" type="image/png" sizes="32x32" href="/static/images/favicon/favicon-32x32.png" />
+            <link rel="icon" type="image/png" sizes="16x16" href="/static/images/favicon/favicon-16x16.png" />
+            <link rel="manifest" href="/static/site.webmanifest" />
+          </head>
+          <body>
+            { children }
+          </body>
+        </html>
+      </ManifestContext.Provider>
     </React.StrictMode>
   );
 }

--- a/app/context/ManifestContext.ts
+++ b/app/context/ManifestContext.ts
@@ -1,0 +1,7 @@
+import { createContext } from 'react';
+
+import { Manifest } from 'app/types';
+
+const ManifestContext = createContext<Manifest>({});
+
+export default ManifestContext;

--- a/app/context/__tests__/ManifestContext.test.js
+++ b/app/context/__tests__/ManifestContext.test.js
@@ -1,0 +1,39 @@
+import React, { useContext } from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import ManifestContext from '../ManifestContext';
+
+const stringifyId = 'manifest-string';
+
+function StringifiedContextValue() {
+  const manifest = useContext(ManifestContext);
+
+  return (
+    <div data-testid={stringifyId}>
+      { JSON.stringify(manifest) }
+    </div>
+  );
+}
+
+const mockedManifestValue = {
+  'app.js': 'https://my.website/scripts/app.hasvalue.js',
+};
+
+describe('ManifestContext', () => {
+  test('default value is an empty object', () => {
+    render(<StringifiedContextValue />);
+
+    expect(screen.getByTestId(stringifyId)).toHaveTextContent(JSON.stringify({}));
+  });
+
+  test('value is passed through the provider', () => {
+    render(
+      <ManifestContext.Provider value={mockedManifestValue}>
+        <StringifiedContextValue />
+      </ManifestContext.Provider>,
+    );
+
+    expect(screen.getByTestId(stringifyId)).toHaveTextContent(JSON.stringify(mockedManifestValue));
+  });
+});

--- a/app/types.ts
+++ b/app/types.ts
@@ -1,7 +1,5 @@
 type Manifest = {
-  'app.js': string;
-  'app.css': string;
-  'vendors.js': string;
+  [key: string]: string;
 };
 
 type HeadingLevel = '1' | '2' | '3' | '4' | '5' | '6';


### PR DESCRIPTION
## Description
Linked to Issue: #126 
In order to conditionally set head tags based on route, we are going to attempt to wrap the document head within a [router](https://reactrouter.com/en/main/routers/picking-a-router). This will allow us to use the [useMatches](https://reactrouter.com/en/main/hooks/use-matches) method of React-Router to define head tags in the route's `handle` property.

To achieve this we need to create a composable/reusable `<Head>` tag for the application to be used within the Layout. The only obstacle to this currently is that the path to the stylesheet references the manifest, passed in through the `<App>` component. To remedy this a `ManifestContext` is created so the Provider can be rendered in `<App>` and a new `<Head>` component can consume this context to retrieve the manifest.

A new context, `app/context/ManifestContext` is created for this purpose.

## Changes
* Wrap the entire app in `ManifestContext` in `app/App/index.tsx`
* Create a new context `app/context/ManifestContext.ts`
* Update type `Manifest` in `app/types.ts` to be any object:
  * Now that the manifest is tracked in a context with a default value, there would be too many places to update whenever the webpack build configurations change

## Steps to QA
* Pull down and switch to this branch
* Run the app, ensure it runs with no errors
* Verify no issues in the browser
