### PR TITLE
[Create `Head` component

### DIFF
--- a/app/App/index.tsx
+++ b/app/App/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Manifest } from 'app/types';
 
 import ManifestContext from 'app/context/ManifestContext';
+import Head from 'app/Head';
 
 import 'app/global.module.scss';
 
@@ -14,23 +15,7 @@ export default function App({ manifest, children }: AppProps): React.ReactElemen
     <React.StrictMode>
       <ManifestContext.Provider value={manifest}>
         <html lang="en">
-          <head>
-            <meta charSet="utf-8" />
-            <title>Tamsui: A Universal JavaScript Application Boilerplate</title>
-            <meta name="author" content="Chi-chi Wang" />
-            <meta
-              name="keywords"
-              content="Tamsui, js, JavaScript, isomorphic, Node.js, React, TypeScript, Express, React-Router, Boilerplate"
-            />
-            <meta name="description" content="An Express/React universal application boilerplate" />
-            <meta name="robots" content="all" />
-            <meta name="viewport" content="width=device-width" />
-            <link rel="stylesheet" type="text/css" href={`/${manifest['app.css']}`} />
-            <link rel="apple-touch-icon" sizes="180x180" href="/static/images/favicon/apple-touch-icon.png" />
-            <link rel="icon" type="image/png" sizes="32x32" href="/static/images/favicon/favicon-32x32.png" />
-            <link rel="icon" type="image/png" sizes="16x16" href="/static/images/favicon/favicon-16x16.png" />
-            <link rel="manifest" href="/static/site.webmanifest" />
-          </head>
+          <Head />
           <body>
             { children }
           </body>

--- a/app/Head/__tests__/__snapshots__/index.test.js.snap
+++ b/app/Head/__tests__/__snapshots__/index.test.js.snap
@@ -1,0 +1,58 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Head component matches the snapshot 1`] = `
+<head>
+  <meta
+    charSet="utf-8"
+  />
+  <title>
+    Tamsui: A Universal JavaScript Application Boilerplate
+  </title>
+  <meta
+    content="Chi-chi Wang"
+    name="author"
+  />
+  <meta
+    content="Tamsui, js, JavaScript, isomorphic, Node.js, React, TypeScript, Express, React-Router, Boilerplate"
+    name="keywords"
+  />
+  <meta
+    content="An Express/React universal application boilerplate"
+    name="description"
+  />
+  <meta
+    content="all"
+    name="robots"
+  />
+  <meta
+    content="width=device-width"
+    name="viewport"
+  />
+  <link
+    href="/Head CSS filepath"
+    rel="stylesheet"
+    type="text/css"
+  />
+  <link
+    href="/static/images/favicon/apple-touch-icon.png"
+    rel="apple-touch-icon"
+    sizes="180x180"
+  />
+  <link
+    href="/static/images/favicon/favicon-32x32.png"
+    rel="icon"
+    sizes="32x32"
+    type="image/png"
+  />
+  <link
+    href="/static/images/favicon/favicon-16x16.png"
+    rel="icon"
+    sizes="16x16"
+    type="image/png"
+  />
+  <link
+    href="/static/site.webmanifest"
+    rel="manifest"
+  />
+</head>
+`;

--- a/app/Head/__tests__/index.test.js
+++ b/app/Head/__tests__/index.test.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+
+import ManifestContext from 'app/context/ManifestContext';
+
+import Head from '../index';
+
+const mockedManifest = {
+  'app.css': 'Head CSS filepath',
+};
+
+describe('Head component', () => {
+  test('matches the snapshot', () => {
+    const tree = renderer.create(
+      <ManifestContext.Provider value={mockedManifest}>
+        <Head />
+      </ManifestContext.Provider>,
+    ).toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/app/Head/index.tsx
+++ b/app/Head/index.tsx
@@ -1,0 +1,30 @@
+import React, { useContext } from 'react';
+
+import ManifestContext from 'app/context/ManifestContext';
+import type { Manifest } from 'app/types';
+
+function Head() {
+  const manifest: Manifest = useContext(ManifestContext);
+
+  return (
+    <head>
+      <meta charSet="utf-8" />
+      <title>Tamsui: A Universal JavaScript Application Boilerplate</title>
+      <meta name="author" content="Chi-chi Wang" />
+      <meta
+        name="keywords"
+        content="Tamsui, js, JavaScript, isomorphic, Node.js, React, TypeScript, Express, React-Router, Boilerplate"
+      />
+      <meta name="description" content="An Express/React universal application boilerplate" />
+      <meta name="robots" content="all" />
+      <meta name="viewport" content="width=device-width" />
+      <link rel="stylesheet" type="text/css" href={`/${manifest['app.css']}`} />
+      <link rel="apple-touch-icon" sizes="180x180" href="/static/images/favicon/apple-touch-icon.png" />
+      <link rel="icon" type="image/png" sizes="32x32" href="/static/images/favicon/favicon-32x32.png" />
+      <link rel="icon" type="image/png" sizes="16x16" href="/static/images/favicon/favicon-16x16.png" />
+      <link rel="manifest" href="/static/site.webmanifest" />
+    </head>
+  );
+}
+
+export default Head;


### PR DESCRIPTION
## Description
Linked to Issue: #126
Create `app/Head` component to render the document head and migrate contents of the head tag in `app/App` into it. This prepares the project to wrap the entire application in the router, and for the `html` root to be rendered by the `Layout`.

## Changes
* Replace document `head` tag with `Head` component in `app/App/index.tsx`
* Create `Head` component `app/Head/index.tsx`
  * Use `ManifestContext` to retrieve the build manifest

## Steps to QA
* Pull down and switch to this branch
* Run the app to ensure it runs without issue
* Verify in browser that the app renders without error
