### PR TITLE
Create hook: `useRouteHead` and use it to apply page-specific titles

### DIFF
--- a/app/HTMLBody/__tests__/__snapshots__/index.test.js.snap
+++ b/app/HTMLBody/__tests__/__snapshots__/index.test.js.snap
@@ -5,58 +5,9 @@ exports[`HTMLBody Component matches child snapshot 1`] = `
   lang="en"
 >
   <head>
-    <meta
-      charSet="utf-8"
-    />
     <title>
-      Tamsui: A Universal JavaScript Application Boilerplate
+      HTMLBody Test
     </title>
-    <meta
-      content="Chi-chi Wang"
-      name="author"
-    />
-    <meta
-      content="Tamsui, js, JavaScript, isomorphic, Node.js, React, TypeScript, Express, React-Router, Boilerplate"
-      name="keywords"
-    />
-    <meta
-      content="An Express/React universal application boilerplate"
-      name="description"
-    />
-    <meta
-      content="all"
-      name="robots"
-    />
-    <meta
-      content="width=device-width"
-      name="viewport"
-    />
-    <link
-      href="/HTML Body CSS path"
-      rel="stylesheet"
-      type="text/css"
-    />
-    <link
-      href="/static/images/favicon/apple-touch-icon.png"
-      rel="apple-touch-icon"
-      sizes="180x180"
-    />
-    <link
-      href="/static/images/favicon/favicon-32x32.png"
-      rel="icon"
-      sizes="32x32"
-      type="image/png"
-    />
-    <link
-      href="/static/images/favicon/favicon-16x16.png"
-      rel="icon"
-      sizes="16x16"
-      type="image/png"
-    />
-    <link
-      href="/static/site.webmanifest"
-      rel="manifest"
-    />
   </head>
   <body>
     <h1>
@@ -71,58 +22,9 @@ exports[`HTMLBody Component matches no-child snapshot 1`] = `
   lang="en"
 >
   <head>
-    <meta
-      charSet="utf-8"
-    />
     <title>
-      Tamsui: A Universal JavaScript Application Boilerplate
+      HTMLBody Test
     </title>
-    <meta
-      content="Chi-chi Wang"
-      name="author"
-    />
-    <meta
-      content="Tamsui, js, JavaScript, isomorphic, Node.js, React, TypeScript, Express, React-Router, Boilerplate"
-      name="keywords"
-    />
-    <meta
-      content="An Express/React universal application boilerplate"
-      name="description"
-    />
-    <meta
-      content="all"
-      name="robots"
-    />
-    <meta
-      content="width=device-width"
-      name="viewport"
-    />
-    <link
-      href="/HTML Body CSS path"
-      rel="stylesheet"
-      type="text/css"
-    />
-    <link
-      href="/static/images/favicon/apple-touch-icon.png"
-      rel="apple-touch-icon"
-      sizes="180x180"
-    />
-    <link
-      href="/static/images/favicon/favicon-32x32.png"
-      rel="icon"
-      sizes="32x32"
-      type="image/png"
-    />
-    <link
-      href="/static/images/favicon/favicon-16x16.png"
-      rel="icon"
-      sizes="16x16"
-      type="image/png"
-    />
-    <link
-      href="/static/site.webmanifest"
-      rel="manifest"
-    />
   </head>
   <body />
 </html>

--- a/app/HTMLBody/__tests__/index.test.js
+++ b/app/HTMLBody/__tests__/index.test.js
@@ -11,6 +11,16 @@ function ChildComponent() {
   );
 }
 
+function MockedHead() {
+  return (
+    <head>
+      <title>HTMLBody Test</title>
+    </head>
+  );
+}
+
+jest.mock('app/Head', () => MockedHead);
+
 const mockedManifest = {
   'app.css': 'HTML Body CSS path',
 };

--- a/app/Head/__tests__/__snapshots__/index.test.js.snap
+++ b/app/Head/__tests__/__snapshots__/index.test.js.snap
@@ -1,12 +1,69 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Head component matches the snapshot 1`] = `
+exports[`Head component matches the no route head snapshot 1`] = `
 <head>
   <meta
     charSet="utf-8"
   />
   <title>
     Tamsui: A Universal JavaScript Application Boilerplate
+  </title>
+  <meta
+    content="Chi-chi Wang"
+    name="author"
+  />
+  <meta
+    content="Tamsui, js, JavaScript, isomorphic, Node.js, React, TypeScript, Express, React-Router, Boilerplate"
+    name="keywords"
+  />
+  <meta
+    content="An Express/React universal application boilerplate"
+    name="description"
+  />
+  <meta
+    content="all"
+    name="robots"
+  />
+  <meta
+    content="width=device-width"
+    name="viewport"
+  />
+  <link
+    href="/Head CSS filepath"
+    rel="stylesheet"
+    type="text/css"
+  />
+  <link
+    href="/static/images/favicon/apple-touch-icon.png"
+    rel="apple-touch-icon"
+    sizes="180x180"
+  />
+  <link
+    href="/static/images/favicon/favicon-32x32.png"
+    rel="icon"
+    sizes="32x32"
+    type="image/png"
+  />
+  <link
+    href="/static/images/favicon/favicon-16x16.png"
+    rel="icon"
+    sizes="16x16"
+    type="image/png"
+  />
+  <link
+    href="/static/site.webmanifest"
+    rel="manifest"
+  />
+</head>
+`;
+
+exports[`Head component matches the route title snapshot 1`] = `
+<head>
+  <meta
+    charSet="utf-8"
+  />
+  <title>
+    route has PageHandle with title | Tamsui
   </title>
   <meta
     content="Chi-chi Wang"

--- a/app/Head/__tests__/index.test.js
+++ b/app/Head/__tests__/index.test.js
@@ -2,15 +2,38 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 
 import ManifestContext from 'app/context/ManifestContext';
+import useRouteHead from 'app/hooks/useRouteHead';
 
 import Head from '../index';
+
+jest.mock('app/hooks/useRouteHead', () => jest.fn());
 
 const mockedManifest = {
   'app.css': 'Head CSS filepath',
 };
 
 describe('Head component', () => {
-  test('matches the snapshot', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('matches the no route head snapshot', () => {
+    useRouteHead.mockReturnValueOnce({});
+
+    const tree = renderer.create(
+      <ManifestContext.Provider value={mockedManifest}>
+        <Head />
+      </ManifestContext.Provider>,
+    ).toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('matches the route title snapshot', () => {
+    useRouteHead.mockReturnValueOnce({
+      title: 'route has PageHandle with title',
+    });
+
     const tree = renderer.create(
       <ManifestContext.Provider value={mockedManifest}>
         <Head />

--- a/app/Head/index.tsx
+++ b/app/Head/index.tsx
@@ -1,15 +1,23 @@
 import React, { useContext } from 'react';
 
 import ManifestContext from 'app/context/ManifestContext';
+import useRouteHead from 'app/hooks/useRouteHead';
 import type { Manifest } from 'app/types';
 
 function Head() {
   const manifest: Manifest = useContext(ManifestContext);
+  const head = useRouteHead();
+
+  const defaultTitle = 'Tamsui: A Universal JavaScript Application Boilerplate';
+  const titleSuffix = '| Tamsui';
+  const title = head?.title
+    ? `${head.title} ${titleSuffix}`
+    : defaultTitle;
 
   return (
     <head>
       <meta charSet="utf-8" />
-      <title>Tamsui: A Universal JavaScript Application Boilerplate</title>
+      <title>{ title }</title>
       <meta name="author" content="Chi-chi Wang" />
       <meta
         name="keywords"

--- a/app/Layout/__tests__/__snapshots__/index.test.js.snap
+++ b/app/Layout/__tests__/__snapshots__/index.test.js.snap
@@ -5,58 +5,9 @@ exports[`Layout Component - default matches no-child snapshot 1`] = `
   lang="en"
 >
   <head>
-    <meta
-      charSet="utf-8"
-    />
     <title>
-      Tamsui: A Universal JavaScript Application Boilerplate
+      Layout Test
     </title>
-    <meta
-      content="Chi-chi Wang"
-      name="author"
-    />
-    <meta
-      content="Tamsui, js, JavaScript, isomorphic, Node.js, React, TypeScript, Express, React-Router, Boilerplate"
-      name="keywords"
-    />
-    <meta
-      content="An Express/React universal application boilerplate"
-      name="description"
-    />
-    <meta
-      content="all"
-      name="robots"
-    />
-    <meta
-      content="width=device-width"
-      name="viewport"
-    />
-    <link
-      href="/undefined"
-      rel="stylesheet"
-      type="text/css"
-    />
-    <link
-      href="/static/images/favicon/apple-touch-icon.png"
-      rel="apple-touch-icon"
-      sizes="180x180"
-    />
-    <link
-      href="/static/images/favicon/favicon-32x32.png"
-      rel="icon"
-      sizes="32x32"
-      type="image/png"
-    />
-    <link
-      href="/static/images/favicon/favicon-16x16.png"
-      rel="icon"
-      sizes="16x16"
-      type="image/png"
-    />
-    <link
-      href="/static/site.webmanifest"
-      rel="manifest"
-    />
   </head>
   <body>
     <section

--- a/app/Layout/__tests__/index.test.js
+++ b/app/Layout/__tests__/index.test.js
@@ -5,6 +5,15 @@ import useResetScroll from 'app/hooks/useResetScroll';
 
 import Layout from '../index';
 
+function MockedHead() {
+  return (
+    <head>
+      <title>Layout Test</title>
+    </head>
+  );
+}
+
+jest.mock('app/Head', () => MockedHead);
 jest.mock('app/hooks/useResetScroll', () => jest.fn());
 
 function RouterWrappedLayout() {

--- a/app/dataRoutes/__tests__/index.test.js
+++ b/app/dataRoutes/__tests__/index.test.js
@@ -49,7 +49,7 @@ jest.mock('pages/Home', function MockHome() {
 jest.mock('pages/Documentation', function MockDocumentation() {
   return MockedDocumentation;
 });
-jest.mock('pages/ErrorPage', function MockCounter() {
+jest.mock('pages/ErrorPage', function MockErrorPage() {
   return MockedErrorPage;
 });
 jest.mock('pages/NotFound', function MockNotFound() {
@@ -136,7 +136,7 @@ describe('dataRoutes', () => {
       }));
     });
 
-    test('assigns the Counter component', () => {
+    test('assigns the Documentation component', () => {
       expect(documentationRoute).toEqual(expect.objectContaining({
         path,
         Component: Documentation,
@@ -158,7 +158,7 @@ describe('dataRoutes', () => {
       }));
     });
 
-    test('assigns the Counter component', () => {
+    test('assigns the ErrorPage component', () => {
       expect(errorRoute).toEqual(expect.objectContaining({
         path,
         Component: ErrorPage,

--- a/app/dataRoutes/index.ts
+++ b/app/dataRoutes/index.ts
@@ -3,9 +3,15 @@ import { RouteObject } from 'react-router-dom';
 import Layout from 'app/Layout';
 
 import Home from 'pages/Home';
+
 import Documentation from 'pages/Documentation';
+import DocumentationHandle from 'pages/Documentation/handle';
+
 import ErrorPage from 'pages/ErrorPage';
+import ErrorPageHandle from 'pages/ErrorPage/handle';
+
 import NotFound from 'pages/NotFound';
+import NotFoundHandle from 'pages/NotFound/handle';
 
 import withErrorBoundary from './withErrorBoundary';
 
@@ -20,14 +26,17 @@ const dataRoutes: RouteObject[] = [
       withErrorBoundary({
         path: '/documentation',
         Component: Documentation,
+        handle: DocumentationHandle,
       }),
       withErrorBoundary({
         path: '/error',
         Component: ErrorPage,
+        handle: ErrorPageHandle,
       }),
       withErrorBoundary({
         path: '*',
         Component: NotFound,
+        handle: NotFoundHandle,
       }),
     ],
   }),

--- a/app/hooks/README.md
+++ b/app/hooks/README.md
@@ -1,6 +1,9 @@
 # Hooks
 This directory houses [custom React hooks](https://react.dev/learn/reusing-logic-with-custom-hooks) created for the boilerplate.
 
+* [useResetScroll](#useresetscroll)
+* [useRouteHead](#useroutehead)
+
 ## useResetScroll
 
 [useResetScroll](./useResetScroll.ts) is a hook created specifically for Layout components that utilize the [React Router Outlet](https://reactrouter.com/en/main/components/outlet). [Links](https://reactrouter.com/en/main/components/link) that navigate between pages under the same layout do not reset the browser window's scroll position upon navigation. To remedy this, this hook will be used to explicitly trigger a scroll reset back to the top-left of the browser window upon route change.
@@ -37,3 +40,91 @@ import InternalLink from 'app/components/InternalLink';
 ```
 
 If the target page does not contain an element whose `id` attribute matches the location hash, this hook will scroll the browser to the top-left of the window instead.
+
+## useRouteHead
+
+[useRouteHead](./useRouteHead.ts) is a hook created to retrieve the property `head` inside of a [route handle](https://reactrouter.com/en/main/route/route#handle). The purpose is to allow developers the ability to set head tags on a per-page basis. Under the hood, `useRouteHead` leverages React Router's [useMatches](https://reactrouter.com/en/main/hooks/use-matches) and [useLocation](https://reactrouter.com/en/main/hooks/use-location) hooks.
+
+If a handle for a route exists, and if it is a `PageHandle` (defined in [app/types.ts](../types.ts)), the `head` attribute of the PageHandle is returned. Otherwise, an empty object is returned.
+
+To add a PageHandle to a data route, define an object in the `handle` property of a route definition and give it a `head` property:
+
+```javascript
+// dataRoutes.jsx
+
+import Home from 'pages/Home';
+import Documentation from 'pages/Documentation';
+import BrowserDocumentation from 'pages/Documentation/BrowserDocumentation';
+import NativeDocumentation from 'pages/Documentation/NativeDocumentation';
+import ErrorPage from 'pages/ErrorPage';
+import NotFound from 'pages/NotFound';
+
+const dataRoutes = [{
+  path: '/',
+  Component: Home,
+  handle: {
+    head: {
+      title: 'Home Page',
+      tags: (
+        <>
+          <meta name="description" content="Awesome Product!" />
+          <meta name="robots" content="all" />
+        </>
+      ),
+    },
+  },
+}, {
+  path: '/documentation',
+  Component: Documentation,
+  handle: {
+    head: {
+      title: 'Developer Documentation',
+      tags: (
+        <>
+          <meta name="description" content="Developer documentation for this product" />
+          <meta name="robots" content="all" />
+        </>
+      ),
+    },
+  },
+  children: [{
+    path: '/browser',
+    Component: BrowserDocumentation,
+  }, {
+    path: '/native',
+    Component: NativeDocumentation,
+  }],
+}, {
+  path: '/error',
+  Component: ErrorPage,
+  handle: {
+    head: {
+      title: 'Oopsie!',
+      tags: (
+        <>
+          <meta name="robots" content="none" />
+        </>
+      ),
+    },
+  },
+}, {
+  path: '*',
+  Component: NotFound,
+  handle: {
+    head: {
+      title: 'Page Not Found!',
+      tags: (
+        <>
+          <meta name="robots" content="none" />
+        </>
+      ),
+    },
+  },
+}];
+
+export default dataRoutes;
+```
+
+`useRouteHead()` will return the `head` property of the nearest PageHandler in a route tree. In the above example, if the router location is `/documentation/browser`, it will return the `head` tag from the PageHandler defined in the `/documentation` route.
+
+This hook, in the boilerplate UI, is used in the [app/Head](../Head/index.tsx) component to apply a page title and custom page-level tags.

--- a/app/hooks/__tests__/useRouteHead.test.js
+++ b/app/hooks/__tests__/useRouteHead.test.js
@@ -1,0 +1,151 @@
+import { useLocation, useMatches } from 'react-router-dom';
+
+import useRouteHead from '../useRouteHead';
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useLocation: jest.fn(),
+  useMatches: jest.fn(),
+}));
+
+const segment1 = '/page';
+const segment2 = `${segment1}/section`;
+const segment3 = `${segment2}/article`;
+
+const mockedHead = {
+  title: 'Page Title',
+  tags: ['meta', 'og:description'],
+};
+
+const location = {
+  pathname: segment3,
+};
+
+describe('useRouteHead', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('no matches returned', () => {
+    beforeAll(() => {
+      useLocation.mockReturnValue(location);
+      useMatches.mockReturnValue([]);
+    });
+
+    test('returns empty object when there are no matches returned', () => {
+      const head = useRouteHead();
+
+      expect(head).toEqual({});
+    });
+  });
+
+  describe('no matches with handle', () => {
+    const matchesNoHandle = [{
+      pathname: segment1,
+      handle: undefined,
+    }, {
+      pathname: segment2,
+      handle: undefined,
+    }, {
+      pathname: segment3,
+      handle: undefined,
+    }];
+
+    beforeAll(() => {
+      useLocation.mockReturnValue(location);
+      useMatches.mockReturnValue(matchesNoHandle);
+    });
+
+    test('returns empty object when matches do not contain a handle', () => {
+      const head = useRouteHead();
+
+      expect(head).toEqual({});
+    });
+  });
+
+  describe('matches with handles do not have PageHandles', () => {
+    const matchesNoPageHandle = [{
+      pathname: segment1,
+      handle: 1337,
+    }, {
+      pathname: segment2,
+      handle: 'random data',
+    }, {
+      pathname: segment3,
+      handle: {
+        does: 'not',
+        contain: 'expected',
+        keys: 'in object',
+      },
+    }];
+
+    beforeAll(() => {
+      useLocation.mockReturnValue(location);
+      useMatches.mockReturnValue(matchesNoPageHandle);
+    });
+
+    test('returns empty object when matches do not contain a PageHandle', () => {
+      const head = useRouteHead();
+
+      expect(head).toEqual({});
+    });
+  });
+
+  describe('location match with PageHandle', () => {
+    const matchesHandle = [{
+      pathname: segment1,
+      handle: undefined,
+    }, {
+      pathname: segment2,
+      handle: undefined,
+    }, {
+      pathname: segment3,
+      handle: {
+        head: mockedHead,
+      },
+    }];
+
+    beforeAll(() => {
+      useLocation.mockReturnValue(location);
+      useMatches.mockReturnValue(matchesHandle);
+    });
+
+    test('returns the head value of the handle in the matched route', () => {
+      const head = useRouteHead();
+
+      expect(head).toBe(mockedHead);
+    });
+  });
+
+  describe('exact path match does not have PageHandle', () => {
+    const ancestorMatchWithHandle = [{
+      pathname: segment1,
+      handle: {
+        root: 'path',
+        segment: 'handle',
+      },
+    }, {
+      pathname: segment2,
+      handle: {
+        head: mockedHead,
+      },
+    }, {
+      pathname: segment3,
+      handle: {
+        not: 'a',
+        page: 'handle',
+      },
+    }];
+
+    beforeAll(() => {
+      useLocation.mockReturnValue(location);
+      useMatches.mockReturnValue(ancestorMatchWithHandle);
+    });
+
+    test('returns the head value of the PageHandle of the nearest ancestor', () => {
+      const head = useRouteHead();
+
+      expect(head).toBe(mockedHead);
+    });
+  });
+});

--- a/app/hooks/useRouteHead.ts
+++ b/app/hooks/useRouteHead.ts
@@ -1,0 +1,34 @@
+import { useLocation, useMatches } from 'react-router-dom';
+import type { PageMatch, RouteHead } from 'app/types';
+
+function useRouteHead(): RouteHead {
+  const location = useLocation();
+  const routeMatches = useMatches();
+
+  const locationMatch = routeMatches.find(
+    function matchLocationWithHead(match): match is PageMatch {
+      const pathMatches = match.pathname === location.pathname;
+      const containsHandle = typeof match.handle === 'object';
+      const containsHead = containsHandle
+        && Object.prototype.hasOwnProperty.call(match.handle, 'head');
+
+      return pathMatches && containsHead;
+    },
+  );
+
+  const pathChainMatches = routeMatches.filter(
+    function matchesWithHead(match): match is PageMatch {
+      const containsHandle = typeof match.handle === 'object';
+
+      return containsHandle && Object.prototype.hasOwnProperty.call(match.handle, 'head');
+    },
+  );
+
+  const pathChainMatch = pathChainMatches.length
+    ? pathChainMatches[pathChainMatches.length - 1]
+    : undefined;
+
+  return locationMatch?.handle?.head || pathChainMatch?.handle?.head || {};
+}
+
+export default useRouteHead;

--- a/app/types.ts
+++ b/app/types.ts
@@ -1,10 +1,33 @@
+import React from 'react';
+import type { UIMatch } from 'react-router-dom';
+
+type HeadingLevel = '1' | '2' | '3' | '4' | '5' | '6';
+
 type Manifest = {
   [key: string]: string;
 };
 
-type HeadingLevel = '1' | '2' | '3' | '4' | '5' | '6';
+/**
+ * Route Match and Handle types
+ */
+
+type RouteHead = {
+  title?: string;
+  tags?: React.ReactNode;
+};
+
+type PageHandle = {
+  head?: RouteHead;
+};
+
+interface PageMatch extends UIMatch {
+  handle: PageHandle,
+}
 
 export {
   HeadingLevel,
   Manifest,
+  PageMatch,
+  PageHandle,
+  RouteHead,
 };

--- a/pages/Documentation/handle.tsx
+++ b/pages/Documentation/handle.tsx
@@ -1,0 +1,9 @@
+import type { PageHandle } from 'app/types';
+
+const handle: PageHandle = {
+  head: {
+    title: 'Developer Documentation',
+  },
+};
+
+export default handle;

--- a/pages/ErrorPage/handle.tsx
+++ b/pages/ErrorPage/handle.tsx
@@ -1,0 +1,9 @@
+import type { PageHandle } from 'app/types';
+
+const handle: PageHandle = {
+  head: {
+    title: 'An Error Occurred',
+  },
+};
+
+export default handle;

--- a/pages/NotFound/handle.tsx
+++ b/pages/NotFound/handle.tsx
@@ -1,0 +1,9 @@
+import type { PageHandle } from 'app/types';
+
+const handle: PageHandle = {
+  head: {
+    title: 'Page Not Found',
+  },
+};
+
+export default handle;


### PR DESCRIPTION
## Description
Linked to Issue: #126 
Create a hook `useRouteHead` that leverages React Router's [useMatches](https://reactrouter.com/en/main/hooks/use-matches) and [useLocation](https://reactrouter.com/en/main/hooks/use-location) hooks to fetch a property `head` from a `PageHandle` object passed through the router.

This is used to pass page-specific titles and [head tags](https://developer.mozilla.org/en-US/docs/Learn/HTML/Introduction_to_HTML/The_head_metadata_in_HTML) to the `<Head />` component based on the route. If a route head is found containing a `title` attribute, that will be used to set the title, otherwise it will use a default title string.

Documentation is created in `app/hooks/README.md` for this new `useRouteHead` hook.

This PR creates PageHandles for the routes `/documentation`, `/error`, and `*` containing titles.

## Changes
* Update `app/HTMLBody/__tests__/index.test.js` to mock the `<Head>` component (using `useMatches` requires a component to be wrapped in a data router)
* Update `app/Head/index.tsx` to leverage `useRouteHead` to fetch a route-specific title
  * If found, route-specific title will be used, otherwise uses default site title
* Update `app/Layout/__tests__/index.test.js` to mock the `<Head>` component (using `useMatches` requires a component to be wrapped in a data router)
* Fix erroneous descriptions in `app/dataRoutes/__tests__/index.test.js`
* Add route handles to `app/dataRoutes/index.ts` for `/documentation`, `/error`, `*`
* Add documentation for `useRouteHead` in `app/hooks/README.md`
* Create hook `app/hooks/useRouteHead.ts` to retrieve any Page Handles in the route chain
* Add types `RouteHead`, `PageHandle`, and `PageMatch` to `app/types.ts`
* Create route handle for `/documentation` `pages/Documentation/handle.tsx`
* Create route handle for `/error` `pages/ErrorPage/handle.tsx`
* Create route handle for `*` `pages/NotFound/handle.tsx`

## Steps to QA
* Pull down and switch to this branch
* Run the app and ensure it runs without issue
* Verify in browser that pages render without issue
* Verify page titles change between `/`, `/documentation`, `/error`, and `/foobar`
* Change a title in one of the route handles and see that the respective route changes title tag contents in browser
