### PR TITLE
Add Open Graph tags for pages Home and Documentation

### DIFF
--- a/app/Head/__tests__/__snapshots__/index.test.js.snap
+++ b/app/Head/__tests__/__snapshots__/index.test.js.snap
@@ -54,6 +54,26 @@ exports[`Head component matches the no route head snapshot 1`] = `
     href="/static/site.webmanifest"
     rel="manifest"
   />
+  <meta
+    content="en_US"
+    property="og:locale"
+  />
+  <meta
+    content="https://test.app.head/static/images/site-preview.webp"
+    property="og:image"
+  />
+  <meta
+    content="1200"
+    property="og:image:width"
+  />
+  <meta
+    content="630"
+    property="og:image:height"
+  />
+  <meta
+    content="image/webp"
+    property="og:image:type"
+  />
 </head>
 `;
 
@@ -110,6 +130,26 @@ exports[`Head component matches the route title snapshot 1`] = `
   <link
     href="/static/site.webmanifest"
     rel="manifest"
+  />
+  <meta
+    content="en_US"
+    property="og:locale"
+  />
+  <meta
+    content="https://test.app.head/static/images/site-preview.webp"
+    property="og:image"
+  />
+  <meta
+    content="1200"
+    property="og:image:width"
+  />
+  <meta
+    content="630"
+    property="og:image:height"
+  />
+  <meta
+    content="image/webp"
+    property="og:image:type"
   />
 </head>
 `;

--- a/app/Head/__tests__/__snapshots__/index.test.js.snap
+++ b/app/Head/__tests__/__snapshots__/index.test.js.snap
@@ -77,6 +77,91 @@ exports[`Head component matches the no route head snapshot 1`] = `
 </head>
 `;
 
+exports[`Head component matches the route tags snapshot 1`] = `
+<head>
+  <meta
+    charSet="utf-8"
+  />
+  <title>
+    Tamsui: A Universal JavaScript Application Boilerplate
+  </title>
+  <meta
+    content="Chi-chi Wang"
+    name="author"
+  />
+  <meta
+    content="Tamsui, js, JavaScript, isomorphic, Node.js, React, TypeScript, Express, React-Router, Boilerplate"
+    name="keywords"
+  />
+  <meta
+    content="An Express/React universal application boilerplate"
+    name="description"
+  />
+  <meta
+    content="all"
+    name="robots"
+  />
+  <meta
+    content="width=device-width"
+    name="viewport"
+  />
+  <link
+    href="/Head CSS filepath"
+    rel="stylesheet"
+    type="text/css"
+  />
+  <link
+    href="/static/images/favicon/apple-touch-icon.png"
+    rel="apple-touch-icon"
+    sizes="180x180"
+  />
+  <link
+    href="/static/images/favicon/favicon-32x32.png"
+    rel="icon"
+    sizes="32x32"
+    type="image/png"
+  />
+  <link
+    href="/static/images/favicon/favicon-16x16.png"
+    rel="icon"
+    sizes="16x16"
+    type="image/png"
+  />
+  <link
+    href="/static/site.webmanifest"
+    rel="manifest"
+  />
+  <meta
+    content="en_US"
+    property="og:locale"
+  />
+  <meta
+    content="https://test.app.head/static/images/site-preview.webp"
+    property="og:image"
+  />
+  <meta
+    content="1200"
+    property="og:image:width"
+  />
+  <meta
+    content="630"
+    property="og:image:height"
+  />
+  <meta
+    content="image/webp"
+    property="og:image:type"
+  />
+  <meta
+    content="dootaloot doot"
+    property="fugazi"
+  />
+  <meta
+    content="you're gonna to have to figure that out for yourself"
+    property="destiny"
+  />
+</head>
+`;
+
 exports[`Head component matches the route title snapshot 1`] = `
 <head>
   <meta

--- a/app/Head/__tests__/index.test.js
+++ b/app/Head/__tests__/index.test.js
@@ -12,6 +12,15 @@ const mockedManifest = {
   'app.css': 'Head CSS filepath',
 };
 
+function CustomHeadTags() {
+  return (
+    <>
+      <meta property="fugazi" content="dootaloot doot" />
+      <meta property="destiny" content="you're gonna to have to figure that out for yourself" />
+    </>
+  );
+}
+
 describe('Head component', () => {
   beforeAll(() => {
     global.PROJECT_URL = 'https://test.app.head';
@@ -40,6 +49,20 @@ describe('Head component', () => {
   test('matches the route title snapshot', () => {
     useRouteHead.mockReturnValueOnce({
       title: 'route has PageHandle with title',
+    });
+
+    const tree = renderer.create(
+      <ManifestContext.Provider value={mockedManifest}>
+        <Head />
+      </ManifestContext.Provider>,
+    ).toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('matches the route tags snapshot', () => {
+    useRouteHead.mockReturnValueOnce({
+      tags: <CustomHeadTags />,
     });
 
     const tree = renderer.create(

--- a/app/Head/__tests__/index.test.js
+++ b/app/Head/__tests__/index.test.js
@@ -13,8 +13,16 @@ const mockedManifest = {
 };
 
 describe('Head component', () => {
+  beforeAll(() => {
+    global.PROJECT_URL = 'https://test.app.head';
+  });
+
   beforeEach(() => {
     jest.clearAllMocks();
+  });
+
+  afterAll(() => {
+    delete global.PROJECT_URL;
   });
 
   test('matches the no route head snapshot', () => {

--- a/app/Head/index.tsx
+++ b/app/Head/index.tsx
@@ -15,6 +15,8 @@ function Head() {
     ? `${head.title} ${titleSuffix}`
     : defaultTitle;
 
+  const PageSpecificHeadTags = head?.tags === undefined ? null : head.tags;
+
   return (
     <head>
       <meta charSet="utf-8" />
@@ -37,6 +39,7 @@ function Head() {
       <meta property="og:image:width" content="1200" />
       <meta property="og:image:height" content="630" />
       <meta property="og:image:type" content="image/webp" />
+      { PageSpecificHeadTags }
     </head>
   );
 }

--- a/app/Head/index.tsx
+++ b/app/Head/index.tsx
@@ -1,3 +1,4 @@
+/* global PROJECT_URL */
 import React, { useContext } from 'react';
 
 import ManifestContext from 'app/context/ManifestContext';
@@ -31,6 +32,11 @@ function Head() {
       <link rel="icon" type="image/png" sizes="32x32" href="/static/images/favicon/favicon-32x32.png" />
       <link rel="icon" type="image/png" sizes="16x16" href="/static/images/favicon/favicon-16x16.png" />
       <link rel="manifest" href="/static/site.webmanifest" />
+      <meta property="og:locale" content="en_US" />
+      <meta property="og:image" content={`${PROJECT_URL}/static/images/site-preview.webp`} />
+      <meta property="og:image:width" content="1200" />
+      <meta property="og:image:height" content="630" />
+      <meta property="og:image:type" content="image/webp" />
     </head>
   );
 }

--- a/app/dataRoutes/__tests__/index.test.js
+++ b/app/dataRoutes/__tests__/index.test.js
@@ -118,6 +118,11 @@ describe('dataRoutes', () => {
       expect(homeRoute).toEqual(expect.objectContaining({
         path,
         Component: Home,
+        handle: expect.objectContaining({
+          head: expect.objectContaining({
+            tags: expect.any(Object),
+          }),
+        }),
       }));
     });
   });
@@ -140,6 +145,12 @@ describe('dataRoutes', () => {
       expect(documentationRoute).toEqual(expect.objectContaining({
         path,
         Component: Documentation,
+        handle: expect.objectContaining({
+          head: expect.objectContaining({
+            title: expect.any(String),
+            tags: expect.any(Object),
+          }),
+        }),
       }));
     });
   });

--- a/app/dataRoutes/index.ts
+++ b/app/dataRoutes/index.ts
@@ -3,6 +3,7 @@ import { RouteObject } from 'react-router-dom';
 import Layout from 'app/Layout';
 
 import Home from 'pages/Home';
+import HomeHandle from 'pages/Home/handle';
 
 import Documentation from 'pages/Documentation';
 import DocumentationHandle from 'pages/Documentation/handle';
@@ -22,6 +23,7 @@ const dataRoutes: RouteObject[] = [
       withErrorBoundary({
         path: '/',
         Component: Home,
+        handle: HomeHandle,
       }),
       withErrorBoundary({
         path: '/documentation',

--- a/app/globals.d.ts
+++ b/app/globals.d.ts
@@ -2,3 +2,4 @@ declare module '*.module.scss';
 
 declare const PORT: number;
 declare const SERVE_STATIC: boolean;
+declare const PROJECT_URL: string;

--- a/pages/Documentation/Head.tsx
+++ b/pages/Documentation/Head.tsx
@@ -1,0 +1,18 @@
+/* global PROJECT_URL */
+import React from 'react';
+
+function Head() {
+  const url = `${PROJECT_URL}/documentation`;
+
+  return (
+    <>
+      <meta property="og:type" content="article" />
+      <meta property="og:author" content="Chi-chi Wang" />
+      <meta property="og:title" content="Developer Documentation for Tamsui: React/Express universal JavaScript boilerplate" />
+      <meta property="og:description" content="Set up a universal JavaScript application on the Tamsui boilerplate." />
+      <meta property="og:url" content={url} />
+    </>
+  );
+}
+
+export default Head;

--- a/pages/Documentation/__tests__/Head.test.js
+++ b/pages/Documentation/__tests__/Head.test.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+
+import Head from '../Head';
+
+describe('Documentation/Head component', () => {
+  beforeAll(() => {
+    global.PROJECT_URL = 'https://documentation.head.test';
+  });
+
+  afterAll(() => {
+    delete global.PROJECT_URL;
+  });
+
+  test('matches the snapshot', () => {
+    const tree = renderer.create(<Head />).toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/pages/Documentation/__tests__/__snapshots__/Head.test.js.snap
+++ b/pages/Documentation/__tests__/__snapshots__/Head.test.js.snap
@@ -1,0 +1,26 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Documentation/Head component matches the snapshot 1`] = `
+[
+  <meta
+    content="article"
+    property="og:type"
+  />,
+  <meta
+    content="Chi-chi Wang"
+    property="og:author"
+  />,
+  <meta
+    content="Developer Documentation for Tamsui: React/Express universal JavaScript boilerplate"
+    property="og:title"
+  />,
+  <meta
+    content="Set up a universal JavaScript application on the Tamsui boilerplate."
+    property="og:description"
+  />,
+  <meta
+    content="https://documentation.head.test/documentation"
+    property="og:url"
+  />,
+]
+`;

--- a/pages/Documentation/handle.tsx
+++ b/pages/Documentation/handle.tsx
@@ -1,8 +1,12 @@
+import React from 'react';
 import type { PageHandle } from 'app/types';
+
+import Head from './Head';
 
 const handle: PageHandle = {
   head: {
     title: 'Developer Documentation',
+    tags: <Head />,
   },
 };
 

--- a/pages/Home/Head.tsx
+++ b/pages/Home/Head.tsx
@@ -1,0 +1,17 @@
+/* global PROJECT_URL */
+import React from 'react';
+
+function Head() {
+  const url = `${PROJECT_URL}`;
+
+  return (
+    <>
+      <meta property="og:type" content="website" />
+      <meta property="og:title" content="Tamsui: A React/Express universal JavaScript boilerplate" />
+      <meta property="og:description" content="Build a universal JavaScript application using React and Express." />
+      <meta property="og:url" content={url} />
+    </>
+  );
+}
+
+export default Head;

--- a/pages/Home/__tests__/Head.test.js
+++ b/pages/Home/__tests__/Head.test.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+
+import Head from '../Head';
+
+describe('Home/Head component', () => {
+  beforeAll(() => {
+    global.PROJECT_URL = 'https://home.head.test';
+  });
+
+  afterAll(() => {
+    delete global.PROJECT_URL;
+  });
+
+  test('matches the snapshot', () => {
+    const tree = renderer.create(<Head />).toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/pages/Home/__tests__/__snapshots__/Head.test.js.snap
+++ b/pages/Home/__tests__/__snapshots__/Head.test.js.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Home/Head component matches the snapshot 1`] = `
+[
+  <meta
+    content="website"
+    property="og:type"
+  />,
+  <meta
+    content="Tamsui: A React/Express universal JavaScript boilerplate"
+    property="og:title"
+  />,
+  <meta
+    content="Build a universal JavaScript application using React and Express."
+    property="og:description"
+  />,
+  <meta
+    content="https://home.head.test"
+    property="og:url"
+  />,
+]
+`;

--- a/pages/Home/handle.tsx
+++ b/pages/Home/handle.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import type { PageHandle } from 'app/types';
+
+import Head from './Head';
+
+const handle: PageHandle = {
+  head: {
+    tags: <Head />,
+  },
+};
+
+export default handle;

--- a/project-configs.js
+++ b/project-configs.js
@@ -2,9 +2,11 @@ module.exports = {
   development: {
     PORT: 8080,
     SERVE_STATIC: true,
+    PROJECT_URL: 'http://127.0.0.1',
   },
   production: {
     PORT: 3000,
     SERVE_STATIC: false,
+    PROJECT_URL: 'https://tamsui.dev',
   },
 };

--- a/project-configs.js
+++ b/project-configs.js
@@ -2,11 +2,11 @@ module.exports = {
   development: {
     PORT: 8080,
     SERVE_STATIC: true,
-    PROJECT_URL: 'http://127.0.0.1',
+    PROJECT_URL: JSON.stringify('http://127.0.0.1:8080'),
   },
   production: {
     PORT: 3000,
     SERVE_STATIC: false,
-    PROJECT_URL: 'https://tamsui.dev',
+    PROJECT_URL: JSON.stringify('https://tamsui.dev'),
   },
 };


### PR DESCRIPTION
## Description
Linked to Issue: #126
Add [Open Graph](https://ogp.me/) meta tags for the Home and Documentation pages. To do so, a new Project Configuration `PROJECT_URL` is created to set the target URL of the project in both development and production. This is used to populate the `og:url` and `og:image` meta tags with the correct path to both the [canonical url](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel#canonical) and the preview image.

## Changes
* Update `app/Head/index.tsx`
  * Add site-wide Open Graph meta tags to head tag:
    * `og:locale`
    * `og:image`
    * `og:image:width`
    * `og:image:height`
    * `og:image:type`
  * Append any tags supplied to the `head` attribute of the PageHandle if found
* Assign `pages/Home/handle` value to the handle for the `/` route
* Declare global Project Configuration variable `PROJECT_URL` in `app/globals.d.ts`
* Render page-specific head tags in `pages/Documentation/Head.tsx`
* Add page-specific head tags to `pages/Documentation/handle.tsx`
* Render page-specific head tags in `pages/Home/Head.tsx`
* Create Home page handle in `pages/Home/handle.tsx`
* Add environment-specific build values for `PROJECT_URL` in `project-configs.js`

## Steps to QA
* Pull down and switch to this branch
* Run the app and ensure no issues occur
* Verify in browser:
  * Page-specific meta tags appear on the `/` route
  * Page-specific meta tags appear on the `/documentation` route
  * New site-wide Open Graph meta tags appear on all routes (including `/error` and `/foobar`)
