### PR TITLE
Add canonical link to head tags for pages Home and Documentation

### DIFF
--- a/pages/Documentation/Head.tsx
+++ b/pages/Documentation/Head.tsx
@@ -11,6 +11,7 @@ function Head() {
       <meta property="og:title" content="Developer Documentation for Tamsui: React/Express universal JavaScript boilerplate" />
       <meta property="og:description" content="Set up a universal JavaScript application on the Tamsui boilerplate." />
       <meta property="og:url" content={url} />
+      <link href={url} rel="canonical" />
     </>
   );
 }

--- a/pages/Documentation/__tests__/__snapshots__/Head.test.js.snap
+++ b/pages/Documentation/__tests__/__snapshots__/Head.test.js.snap
@@ -22,5 +22,9 @@ exports[`Documentation/Head component matches the snapshot 1`] = `
     content="https://documentation.head.test/documentation"
     property="og:url"
   />,
+  <link
+    href="https://documentation.head.test/documentation"
+    rel="canonical"
+  />,
 ]
 `;

--- a/pages/Home/Head.tsx
+++ b/pages/Home/Head.tsx
@@ -10,6 +10,7 @@ function Head() {
       <meta property="og:title" content="Tamsui: A React/Express universal JavaScript boilerplate" />
       <meta property="og:description" content="Build a universal JavaScript application using React and Express." />
       <meta property="og:url" content={url} />
+      <link href={url} rel="canonical" />
     </>
   );
 }

--- a/pages/Home/__tests__/__snapshots__/Head.test.js.snap
+++ b/pages/Home/__tests__/__snapshots__/Head.test.js.snap
@@ -18,5 +18,9 @@ exports[`Home/Head component matches the snapshot 1`] = `
     content="https://home.head.test"
     property="og:url"
   />,
+  <link
+    href="https://home.head.test"
+    rel="canonical"
+  />,
 ]
 `;


### PR DESCRIPTION
## Description
Linked to Issue: #126
Add [canonical links](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Choosing_between_www_and_non-www_URLs#using_link_relcanonical) to the head tags for `/` and `/documentation` to avoid hashes and query params from impacting indexing from search crawlers.

## Changes
* Add canonical link to `pages/Documentation/Head.tsx`
* Add canonical link to `pages/Home/Head.tsx`

## Steps to QA
* Pull down and switch to this branch
* Run the app and verify no issues
* Verify in browser that the correct canonical links appear on `/` and `/documentation`
