### PR TITLE
Chichi/page handles

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -57,6 +57,7 @@ A config file `project-configs.js` exists in the project root directory. These v
 Currently the following variables are used:
 * `PORT` (number): The port the express server will run on.
 * `SERVE_STATIC` (boolean): Whether the Express server should serve static assets located in `dist/static/`, `dist/styles/`, and `dist/scripts`.
+* `PROJECT_URL` (string): The intended deployment URL of the application in each environment, used to set [canonical links](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel#canonical) and [Open Graph](https://ogp.me/) meta tags.
 
 **Adding configuration variables**
 

--- a/pages/Documentation/ProjectConfigurations.tsx
+++ b/pages/Documentation/ProjectConfigurations.tsx
@@ -86,6 +86,18 @@ function ProjectConfigurations() {
           <span className={styles.highlight}>dist/scripts/</span>
           .
         </li>
+        <li>
+          <span className={styles.highlight}>PROJECT_URL</span>
+          {' (string): The intended deployment URL of the application in each environment, used to set '}
+          <ExternalLink href="https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel#canonical">
+            canonical links
+          </ExternalLink>
+          {' and '}
+          <ExternalLink href="https://ogp.me/">
+            Open Graph
+          </ExternalLink>
+          {' meta tags.'}
+        </li>
       </ul>
 
       <p>

--- a/pages/Documentation/__tests__/__snapshots__/index.test.js.snap
+++ b/pages/Documentation/__tests__/__snapshots__/index.test.js.snap
@@ -2317,6 +2317,30 @@ exports[`Documentation Page Component matches snapshot 1`] = `
           </span>
           .
         </li>
+        <li>
+          <span
+            className="highlight"
+          >
+            PROJECT_URL
+          </span>
+           (string): The intended deployment URL of the application in each environment, used to set 
+          <a
+            href="https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel#canonical"
+            rel="noreferrer"
+            target="_blank"
+          >
+            canonical links
+          </a>
+           and 
+          <a
+            href="https://ogp.me/"
+            rel="noreferrer"
+            target="_blank"
+          >
+            Open Graph
+          </a>
+           meta tags.
+        </li>
       </ul>
       <p>
         <b>


### PR DESCRIPTION
## Description
Linked to Issue: #126 
Add documentation to `docs/README.md` and `/documentation` on the new Project Configuration variable `PROJECT_URL`.

Additionally, add a new section to `docs/README.md`: "Route-Specific Data" to document how to use a [route handle](https://reactrouter.com/en/main/route/route#handle), and the custom hook `useRouteHead`.

## Changes
* Update `docs/README.md`
  * Add documentation for the project config variable `PROJECT_URL` to section: Project Configurations
  * Add section: Route-Specific Data
* Add documentation for project config variable `PROJECT_URL` to `pages/Documentation/ProjectConfigurations.tsx`

## Steps to QA
* View `docs/README.md` and ensure new content looks good
* Pull down and switch to this branch
* Run the app and verify in browser that the addition to `/documentation` looks good
