### PR TITLE
Add to Documentation Page: Route-Specific Data

### DIFF
--- a/app/var.module.scss
+++ b/app/var.module.scss
@@ -17,6 +17,7 @@ $code-colors: (
   "background": #434343,
   "blue": #A5D6FF,
   "darkBlue": #79c0ff,
+  "green": #7EE787,
   "grey": #8B949E,
   "orange": #FFA657,
   "purple": #D2A8FF,

--- a/docs/README.md
+++ b/docs/README.md
@@ -237,7 +237,7 @@ A `PageHandle` object can be passed into a given data route's `handle` field. If
 
 **NOTE**: [app/Head](../app/Head/index.tsx) is rendered by [app/HTMLBody](../app/HTMLBody/index.tsx), which rendered by [app/Layout](../app/Layout/index.tsx). This makes `app/Head` the ideal component to house site-wide [document head](https://developer.mozilla.org/en-US/docs/Web/API/Document/head) tags. To leverage this in new layouts, follow the example set by `app/Layout`: wrap the contents of the layout in `app/HTMLBody` and invoke the hook [useResetScroll](../app/hooks/README.md#useresetscroll) to ensure proper scroll behavior on route change.
 
-A custom hook, [app/hooks/useRouteHead](../app/hooks/README.md#useroutehead) has been created for use in `app/Head` to retrieve the contents of a route's PageHandle `head` property if it exists.
+A custom hook, [app/hooks/useRouteHead](../app/hooks/README.md#useroutehead), has been created for use in `app/Head` to retrieve the contents of a route's PageHandle `head` property if it exists.
 
 To add a `PageHandle` to a data route:
 
@@ -269,14 +269,14 @@ const dataRoutes = [{
       tags: (
         <>
           <meta property="og:title" content="Learn about the best website" />
-          <meta property="og:description" content="A well-reasoned thesis on what makes this website the best one." />
+          <meta property="og:description" content="10 reasons this site is best." />
         </>
       ),
     },
   },
 }];
 
-export default dataRoutes
+export default dataRoutes;
 ```
 
 These `title`s and `tags` will be rendered into the document head only for their respective routes.

--- a/pages/Documentation/RouteSpecificData.tsx
+++ b/pages/Documentation/RouteSpecificData.tsx
@@ -1,0 +1,391 @@
+import React from 'react';
+
+import HeadingBlock from 'app/components/HeadingBlock';
+import ExternalLink from 'app/components/ExternalLink';
+import CopyButton, { ColorModes } from 'app/components/CopyButton';
+
+import styles from './styles.module.scss';
+
+const typedefSnippet = `type RouteHead = {
+  title?: string;
+  tags?: React.ReactNode;
+};
+
+type PageHandle = {
+  head?: RouteHead;
+};`;
+
+const routesSnippet = `// dataRoutes.js
+import Home from 'pages/Home';
+import About from 'pages/About';
+
+const dataRoutes = [{
+  path: '/',
+  Component: Home,
+  handle: {
+    head: {
+      title: 'Welcome to my homepage!',
+      tags: (
+        <>
+        <meta property="og:title" content="Check out my website!" />
+        <meta property="og:description" content="I think it might be the best website ever made." />
+        </>
+      ),
+    },
+  },
+}, {
+  path: '/about',
+  Component: About,
+  handle: {
+    head: {
+      title: 'Some things about my website',
+      tags: (
+        <>
+        <meta property="og:title" content="Learn about the best website" />
+        <meta property="og:description" content="10 reasons this site is best." />
+        </>
+      ),
+    },
+  },
+}];
+
+export default dataRoutes;`;
+
+function RouteSpecificData() {
+  return (
+    <HeadingBlock
+      level="3"
+      id="Route-Specific-Data"
+      heading="Route-Specific Data"
+    >
+      <p>
+        <b>Tamsui</b>
+        {' uses a React Router '}
+        <ExternalLink href="https://reactrouter.com/en/main/routers/router-provider">
+          data router
+        </ExternalLink>
+        {'. A route can be passed a '}
+        <ExternalLink href="https://reactrouter.com/en/main/route/route#handle">
+          handle
+        </ExternalLink>
+        {`, which allows any arbitrary data to be passed to a route, retrieved in a
+         component using the `}
+        <ExternalLink href="https://reactrouter.com/en/main/hooks/use-matches">
+          useMatches
+        </ExternalLink>
+        {' hook.'}
+      </p>
+
+      <p>
+        {'This boilerplate has a baseline implementation of this usage in place, passing a '}
+        <ExternalLink href="https://github.com/chichiwang/tamsui/blob/main/app/types.ts">
+          PageHandle
+        </ExternalLink>
+        {` object. This is intended to pass route-specific or page-specific data to a page
+         component. A `}
+        <span className={styles.highlight}>PageHandle</span>
+        {' is currently defined as:'}
+      </p>
+
+      <div className={styles.codeBlock}>
+        <CopyButton
+          className={styles.copyButton}
+          textToCopy={typedefSnippet}
+          colorMode={ColorModes.light}
+        />
+        <p>
+          <span className={styles.red}>type</span>
+          {' RouteHead '}
+          <span className={styles.darkBlue}>=</span>
+          {' {'}
+          <br />
+          &nbsp;&nbsp;
+          <span className={styles.darkBlue}>title</span>
+          ?: string;
+          <br />
+          &nbsp;&nbsp;
+          <span className={styles.darkBlue}>tags</span>
+          ?: React.ReactNode;
+          <br />
+          {'};'}
+          <br />
+          <br />
+          <span className={styles.red}>type</span>
+          {' PageHandle '}
+          <span className={styles.darkBlue}>=</span>
+          {' {'}
+          <br />
+          &nbsp;&nbsp;
+          <span className={styles.darkBlue}>head</span>
+          ?: RouteHead;
+          <br />
+          {'};'}
+        </p>
+      </div>
+
+      <p>
+        {'A '}
+        <span className={styles.highlight}>PageHandle</span>
+        {' object can be passed into a given data route\'s '}
+        <span className={styles.highlight}>handle</span>
+        {' field. If this '}
+        <span className={styles.highlight}>PageHandle</span>
+        {' contains a '}
+        <span className={styles.highlight}>head</span>
+        {' property with '}
+        <span className={styles.highlight}>title</span>
+        {' or '}
+        <span className={styles.highlight}>tags</span>
+        {' then these values will be used by the '}
+        <ExternalLink href="https://github.com/chichiwang/tamsui/blob/main/app/Head/index.tsx">
+          app/Head
+        </ExternalLink>
+        {' component to set the title and append route-specific head tags to a page.'}
+      </p>
+
+      <p>
+        <b>NOTE</b>
+        {': '}
+        <ExternalLink href="https://github.com/chichiwang/tamsui/blob/main/app/Head/index.tsx">
+          app/Head
+        </ExternalLink>
+        {' is rendered by '}
+        <ExternalLink href="https://github.com/chichiwang/tamsui/blob/main/app/HTMLBody/index.tsx">
+          app/HTMLBody
+        </ExternalLink>
+        {', which rendered by '}
+        <ExternalLink href="https://github.com/chichiwang/tamsui/blob/main/app/Layout/index.tsx">
+          app/Layout
+        </ExternalLink>
+        {'. This makes '}
+        <span className={styles.highlight}>app/Head</span>
+        {' the ideal component to house site-wide '}
+        <ExternalLink href="https://developer.mozilla.org/en-US/docs/Web/API/Document/head">
+          document head
+        </ExternalLink>
+        {' tags. To leverage this in new layouts, follow the example set by '}
+        <span className={styles.highlight}>app/Layout</span>
+        {': wrap the contents of the layout in '}
+        <span className={styles.highlight}>app/HTMLBody</span>
+        {' and invoke the hook '}
+        <ExternalLink href="https://github.com/chichiwang/tamsui/blob/main/app/hooks/README.md#useresetscroll">
+          useResetScroll
+        </ExternalLink>
+        {' to ensure proper scroll behavior on route change.'}
+      </p>
+
+      <p>
+        {'A custom hook, '}
+        <ExternalLink href="https://github.com/chichiwang/tamsui/blob/main/app/hooks/README.md#useroutehead">
+          app/hooks/useRouteHead
+        </ExternalLink>
+        {', has been created for use in '}
+        <span className={styles.highlight}>app/Head</span>
+        {' to retrieve the contents of a route\'s PageHandle '}
+        <span className={styles.highlight}>head</span>
+        {' property if it exists.'}
+      </p>
+
+      <p>
+        {'To add a '}
+        <span className={styles.highlight}>PageHandle</span>
+        {' to a data route:'}
+      </p>
+
+      <div className={styles.codeBlock}>
+        <CopyButton
+          className={styles.copyButton}
+          textToCopy={routesSnippet}
+          colorMode={ColorModes.light}
+        />
+        <p>
+          <span className={styles.grey}>&#47;&#47; dataRoutes.js</span>
+          <br />
+          <span className={styles.red}>import</span>
+          {' '}
+          <span className={styles.orange}>Home</span>
+          {' '}
+          <span className={styles.red}>from</span>
+          {' '}
+          <span className={styles.blue}>&apos;pages/Home&apos;</span>
+          ;
+          <br />
+          <span className={styles.red}>import</span>
+          {' '}
+          <span className={styles.orange}>About</span>
+          {' '}
+          <span className={styles.red}>from</span>
+          {' '}
+          <span className={styles.blue}>&apos;pages/About&apos;</span>
+          ;
+          <br />
+          <br />
+          <span className={styles.red}>const</span>
+          {' dataRoutes '}
+          <span className={styles.darkBlue}>=</span>
+          {' [{'}
+
+          <br />
+          &nbsp;&nbsp;
+          <span className={styles.darkBlue}>path</span>
+          {': '}
+          <span className={styles.blue}>&apos;/&apos;</span>
+          ,
+          <br />
+          &nbsp;&nbsp;
+          <span className={styles.darkBlue}>Component</span>
+          {': '}
+          <span className={styles.orange}>Home</span>
+          ,
+          <br />
+          &nbsp;&nbsp;
+          <span className={styles.darkBlue}>handle</span>
+          {': {'}
+          <br />
+          &nbsp;&nbsp;&nbsp;&nbsp;
+          <span className={styles.darkBlue}>head</span>
+          {': {'}
+          <br />
+          &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+          <span className={styles.darkBlue}>title</span>
+          {': '}
+          <span className={styles.blue}>&apos;Welcome to my homepage!&apos;</span>
+          ,
+          <br />
+          &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+          <span className={styles.darkBlue}>tags</span>
+          : (
+          <br />
+          &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+          <span className={styles.darkBlue}>&lt;&gt;</span>
+          <br />
+          &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+          <span className={styles.darkBlue}>&lt;</span>
+          <span className={styles.green}>meta</span>
+          {' '}
+          <span className={styles.darkBlue}>property =</span>
+          <span className={styles.blue}>&quot;og:title&quot;</span>
+          {' '}
+          <span className={styles.darkBlue}>content =</span>
+          <span className={styles.blue}>&quot;Check out my website!&quot;</span>
+          {' '}
+          <span className={styles.darkBlue}>/&gt;</span>
+          <br />
+          &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+          <span className={styles.darkBlue}>&lt;</span>
+          <span className={styles.green}>meta</span>
+          {' '}
+          <span className={styles.darkBlue}>property =</span>
+          <span className={styles.blue}>&quot;og:description&quot;</span>
+          {' '}
+          <span className={styles.darkBlue}>content =</span>
+          <span className={styles.blue}>
+            &quot;I think it might be the best website ever made.&quot;
+          </span>
+          {' '}
+          <span className={styles.darkBlue}>/&gt;</span>
+          <br />
+          &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+          <span className={styles.darkBlue}>&lt;/&gt;</span>
+          <br />
+          &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;),
+          <br />
+          &nbsp;&nbsp;&nbsp;&nbsp;
+          {'},'}
+          <br />
+          &nbsp;&nbsp;
+          {'},'}
+          <br />
+          {'}, {'}
+
+          <br />
+          &nbsp;&nbsp;
+          <span className={styles.darkBlue}>path</span>
+          {': '}
+          <span className={styles.blue}>&apos;/about&apos;</span>
+          ,
+          <br />
+          &nbsp;&nbsp;
+          <span className={styles.darkBlue}>Component</span>
+          {': '}
+          <span className={styles.orange}>About</span>
+          ,
+          <br />
+          &nbsp;&nbsp;
+          <span className={styles.darkBlue}>handle</span>
+          {': {'}
+          <br />
+          &nbsp;&nbsp;&nbsp;&nbsp;
+          <span className={styles.darkBlue}>head</span>
+          {': {'}
+          <br />
+          &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+          <span className={styles.darkBlue}>title</span>
+          {': '}
+          <span className={styles.blue}>&apos;Some things about my website&apos;</span>
+          ,
+          <br />
+          &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+          <span className={styles.darkBlue}>tags</span>
+          : (
+          <br />
+          &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+          <span className={styles.darkBlue}>&lt;&gt;</span>
+          <br />
+          &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+          <span className={styles.darkBlue}>&lt;</span>
+          <span className={styles.green}>meta</span>
+          {' '}
+          <span className={styles.darkBlue}>property =</span>
+          <span className={styles.blue}>&quot;og:title&quot;</span>
+          {' '}
+          <span className={styles.darkBlue}>content =</span>
+          <span className={styles.blue}>&quot;Learn about the best website&quot;</span>
+          {' '}
+          <span className={styles.darkBlue}>/&gt;</span>
+          <br />
+          &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+          <span className={styles.darkBlue}>&lt;</span>
+          <span className={styles.green}>meta</span>
+          {' '}
+          <span className={styles.darkBlue}>property =</span>
+          <span className={styles.blue}>&quot;og:description&quot;</span>
+          {' '}
+          <span className={styles.darkBlue}>content =</span>
+          <span className={styles.blue}>
+            &quot;10 reasons this site is best.&quot;
+          </span>
+          {' '}
+          <span className={styles.darkBlue}>/&gt;</span>
+          <br />
+          &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+          <span className={styles.darkBlue}>&lt;/&gt;</span>
+          <br />
+          &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;),
+          <br />
+          &nbsp;&nbsp;&nbsp;&nbsp;
+          {'},'}
+          <br />
+          &nbsp;&nbsp;
+          {'},'}
+          <br />
+          {'}];'}
+          <br />
+          <br />
+          <span className={styles.red}>export default</span>
+          {' dataRoutes;'}
+        </p>
+      </div>
+
+      <p>
+        {'These '}
+        <span className={styles.highlight}>title</span>
+        {'s and '}
+        <span className={styles.highlight}>tags</span>
+        {' will be rendered into the document head only for their respective routes.'}
+      </p>
+    </HeadingBlock>
+  );
+}
+
+export default RouteSpecificData;

--- a/pages/Documentation/__tests__/__snapshots__/index.test.js.snap
+++ b/pages/Documentation/__tests__/__snapshots__/index.test.js.snap
@@ -2181,6 +2181,14 @@ exports[`Documentation Page Component matches snapshot 1`] = `
         </li>
         <li>
           <a
+            href="/#Route-Specific-Data"
+            onClick={[Function]}
+          >
+            Route-Specific Data
+          </a>
+        </li>
+        <li>
+          <a
             href="/#Pull-Request-Template"
             onClick={[Function]}
           >
@@ -4431,6 +4439,855 @@ exports[`Documentation Page Component matches snapshot 1`] = `
           InternalLink
         </a>
          has been provided to automatically pass this state object property.
+      </p>
+    </article>
+  </section>
+  <section
+    className="headingBlock"
+  >
+    <div
+      className="container"
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+    >
+      <div
+        className="wrapper"
+      >
+        <h3
+          className="tag"
+        >
+          Route-Specific Data
+        </h3>
+        <a
+          aria-labelledby="Route-Specific-Data"
+          className="link"
+          href="#Route-Specific-Data"
+          id="Route-Specific-Data"
+        >
+          <svg
+            height="1.75rem"
+            viewBox="0 0 24 24"
+            width="1.75rem"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g
+              fill="none"
+              stroke="currentColor"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2.5}
+            >
+              <path
+                d="M14 11.998C14 9.506 11.683 7 8.857 7H7.143C4.303 7 2 9.238 2 11.998c0 2.378 1.71 4.368 4 4.873a5.3 5.3 0 0 0 1.143.124"
+              />
+              <path
+                d="M10 11.998c0 2.491 2.317 4.997 5.143 4.997h1.714c2.84 0 5.143-2.237 5.143-4.997c0-2.379-1.71-4.37-4-4.874A5.3 5.3 0 0 0 16.857 7"
+              />
+            </g>
+          </svg>
+        </a>
+      </div>
+    </div>
+    <article>
+      <p>
+        <b>
+          Tamsui
+        </b>
+         uses a React Router 
+        <a
+          href="https://reactrouter.com/en/main/routers/router-provider"
+          rel="noreferrer"
+          target="_blank"
+        >
+          data router
+        </a>
+        . A route can be passed a 
+        <a
+          href="https://reactrouter.com/en/main/route/route#handle"
+          rel="noreferrer"
+          target="_blank"
+        >
+          handle
+        </a>
+        , which allows any arbitrary data to be passed to a route, retrieved in a
+         component using the 
+        <a
+          href="https://reactrouter.com/en/main/hooks/use-matches"
+          rel="noreferrer"
+          target="_blank"
+        >
+          useMatches
+        </a>
+         hook.
+      </p>
+      <p>
+        This boilerplate has a baseline implementation of this usage in place, passing a 
+        <a
+          href="https://github.com/chichiwang/tamsui/blob/main/app/types.ts"
+          rel="noreferrer"
+          target="_blank"
+        >
+          PageHandle
+        </a>
+         object. This is intended to pass route-specific or page-specific data to a page
+         component. A 
+        <span
+          className="highlight"
+        >
+          PageHandle
+        </span>
+         is currently defined as:
+      </p>
+      <div
+        className="codeBlock"
+      >
+        <div
+          className="copyContainer copyButton"
+        >
+          <div
+            className="copyWrapper lightMode"
+          >
+            <div
+              className="message"
+            >
+              <div
+                className="successMessage"
+              >
+                <span>
+                  Copied!
+                </span>
+              </div>
+              <div
+                className="errorMessage"
+              >
+                <span>
+                  Failed!
+                </span>
+              </div>
+            </div>
+            <button
+              aria-label="Copy text"
+              className="copyButton"
+              onClick={[Function]}
+              type="button"
+            >
+              <svg
+                className="copyIcon"
+                height="1em"
+                viewBox="0 0 24 24"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <g
+                  fill="none"
+                  stroke="currentColor"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                >
+                  <path
+                    d="M7 9.667A2.667 2.667 0 0 1 9.667 7h8.666A2.667 2.667 0 0 1 21 9.667v8.666A2.667 2.667 0 0 1 18.333 21H9.667A2.667 2.667 0 0 1 7 18.333z"
+                  />
+                  <path
+                    d="M4.012 16.737A2 2 0 0 1 3 15V5c0-1.1.9-2 2-2h10c.75 0 1.158.385 1.5 1"
+                  />
+                </g>
+              </svg>
+            </button>
+          </div>
+        </div>
+        <p>
+          <span
+            className="red"
+          >
+            type
+          </span>
+           RouteHead 
+          <span
+            className="darkBlue"
+          >
+            =
+          </span>
+           {
+          <br />
+            
+          <span
+            className="darkBlue"
+          >
+            title
+          </span>
+          ?: string;
+          <br />
+            
+          <span
+            className="darkBlue"
+          >
+            tags
+          </span>
+          ?: React.ReactNode;
+          <br />
+          };
+          <br />
+          <br />
+          <span
+            className="red"
+          >
+            type
+          </span>
+           PageHandle 
+          <span
+            className="darkBlue"
+          >
+            =
+          </span>
+           {
+          <br />
+            
+          <span
+            className="darkBlue"
+          >
+            head
+          </span>
+          ?: RouteHead;
+          <br />
+          };
+        </p>
+      </div>
+      <p>
+        A 
+        <span
+          className="highlight"
+        >
+          PageHandle
+        </span>
+         object can be passed into a given data route's 
+        <span
+          className="highlight"
+        >
+          handle
+        </span>
+         field. If this 
+        <span
+          className="highlight"
+        >
+          PageHandle
+        </span>
+         contains a 
+        <span
+          className="highlight"
+        >
+          head
+        </span>
+         property with 
+        <span
+          className="highlight"
+        >
+          title
+        </span>
+         or 
+        <span
+          className="highlight"
+        >
+          tags
+        </span>
+         then these values will be used by the 
+        <a
+          href="https://github.com/chichiwang/tamsui/blob/main/app/Head/index.tsx"
+          rel="noreferrer"
+          target="_blank"
+        >
+          app/Head
+        </a>
+         component to set the title and append route-specific head tags to a page.
+      </p>
+      <p>
+        <b>
+          NOTE
+        </b>
+        : 
+        <a
+          href="https://github.com/chichiwang/tamsui/blob/main/app/Head/index.tsx"
+          rel="noreferrer"
+          target="_blank"
+        >
+          app/Head
+        </a>
+         is rendered by 
+        <a
+          href="https://github.com/chichiwang/tamsui/blob/main/app/HTMLBody/index.tsx"
+          rel="noreferrer"
+          target="_blank"
+        >
+          app/HTMLBody
+        </a>
+        , which rendered by 
+        <a
+          href="https://github.com/chichiwang/tamsui/blob/main/app/Layout/index.tsx"
+          rel="noreferrer"
+          target="_blank"
+        >
+          app/Layout
+        </a>
+        . This makes 
+        <span
+          className="highlight"
+        >
+          app/Head
+        </span>
+         the ideal component to house site-wide 
+        <a
+          href="https://developer.mozilla.org/en-US/docs/Web/API/Document/head"
+          rel="noreferrer"
+          target="_blank"
+        >
+          document head
+        </a>
+         tags. To leverage this in new layouts, follow the example set by 
+        <span
+          className="highlight"
+        >
+          app/Layout
+        </span>
+        : wrap the contents of the layout in 
+        <span
+          className="highlight"
+        >
+          app/HTMLBody
+        </span>
+         and invoke the hook 
+        <a
+          href="https://github.com/chichiwang/tamsui/blob/main/app/hooks/README.md#useresetscroll"
+          rel="noreferrer"
+          target="_blank"
+        >
+          useResetScroll
+        </a>
+         to ensure proper scroll behavior on route change.
+      </p>
+      <p>
+        A custom hook, 
+        <a
+          href="https://github.com/chichiwang/tamsui/blob/main/app/hooks/README.md#useroutehead"
+          rel="noreferrer"
+          target="_blank"
+        >
+          app/hooks/useRouteHead
+        </a>
+        , has been created for use in 
+        <span
+          className="highlight"
+        >
+          app/Head
+        </span>
+         to retrieve the contents of a route's PageHandle 
+        <span
+          className="highlight"
+        >
+          head
+        </span>
+         property if it exists.
+      </p>
+      <p>
+        To add a 
+        <span
+          className="highlight"
+        >
+          PageHandle
+        </span>
+         to a data route:
+      </p>
+      <div
+        className="codeBlock"
+      >
+        <div
+          className="copyContainer copyButton"
+        >
+          <div
+            className="copyWrapper lightMode"
+          >
+            <div
+              className="message"
+            >
+              <div
+                className="successMessage"
+              >
+                <span>
+                  Copied!
+                </span>
+              </div>
+              <div
+                className="errorMessage"
+              >
+                <span>
+                  Failed!
+                </span>
+              </div>
+            </div>
+            <button
+              aria-label="Copy text"
+              className="copyButton"
+              onClick={[Function]}
+              type="button"
+            >
+              <svg
+                className="copyIcon"
+                height="1em"
+                viewBox="0 0 24 24"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <g
+                  fill="none"
+                  stroke="currentColor"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                >
+                  <path
+                    d="M7 9.667A2.667 2.667 0 0 1 9.667 7h8.666A2.667 2.667 0 0 1 21 9.667v8.666A2.667 2.667 0 0 1 18.333 21H9.667A2.667 2.667 0 0 1 7 18.333z"
+                  />
+                  <path
+                    d="M4.012 16.737A2 2 0 0 1 3 15V5c0-1.1.9-2 2-2h10c.75 0 1.158.385 1.5 1"
+                  />
+                </g>
+              </svg>
+            </button>
+          </div>
+        </div>
+        <p>
+          <span
+            className="grey"
+          >
+            // dataRoutes.js
+          </span>
+          <br />
+          <span
+            className="red"
+          >
+            import
+          </span>
+           
+          <span
+            className="orange"
+          >
+            Home
+          </span>
+           
+          <span
+            className="red"
+          >
+            from
+          </span>
+           
+          <span
+            className="blue"
+          >
+            'pages/Home'
+          </span>
+          ;
+          <br />
+          <span
+            className="red"
+          >
+            import
+          </span>
+           
+          <span
+            className="orange"
+          >
+            About
+          </span>
+           
+          <span
+            className="red"
+          >
+            from
+          </span>
+           
+          <span
+            className="blue"
+          >
+            'pages/About'
+          </span>
+          ;
+          <br />
+          <br />
+          <span
+            className="red"
+          >
+            const
+          </span>
+           dataRoutes 
+          <span
+            className="darkBlue"
+          >
+            =
+          </span>
+           [{
+          <br />
+            
+          <span
+            className="darkBlue"
+          >
+            path
+          </span>
+          : 
+          <span
+            className="blue"
+          >
+            '/'
+          </span>
+          ,
+          <br />
+            
+          <span
+            className="darkBlue"
+          >
+            Component
+          </span>
+          : 
+          <span
+            className="orange"
+          >
+            Home
+          </span>
+          ,
+          <br />
+            
+          <span
+            className="darkBlue"
+          >
+            handle
+          </span>
+          : {
+          <br />
+              
+          <span
+            className="darkBlue"
+          >
+            head
+          </span>
+          : {
+          <br />
+                
+          <span
+            className="darkBlue"
+          >
+            title
+          </span>
+          : 
+          <span
+            className="blue"
+          >
+            'Welcome to my homepage!'
+          </span>
+          ,
+          <br />
+                
+          <span
+            className="darkBlue"
+          >
+            tags
+          </span>
+          : (
+          <br />
+                  
+          <span
+            className="darkBlue"
+          >
+            &lt;&gt;
+          </span>
+          <br />
+                    
+          <span
+            className="darkBlue"
+          >
+            &lt;
+          </span>
+          <span
+            className="green"
+          >
+            meta
+          </span>
+           
+          <span
+            className="darkBlue"
+          >
+            property =
+          </span>
+          <span
+            className="blue"
+          >
+            "og:title"
+          </span>
+           
+          <span
+            className="darkBlue"
+          >
+            content =
+          </span>
+          <span
+            className="blue"
+          >
+            "Check out my website!"
+          </span>
+           
+          <span
+            className="darkBlue"
+          >
+            /&gt;
+          </span>
+          <br />
+                    
+          <span
+            className="darkBlue"
+          >
+            &lt;
+          </span>
+          <span
+            className="green"
+          >
+            meta
+          </span>
+           
+          <span
+            className="darkBlue"
+          >
+            property =
+          </span>
+          <span
+            className="blue"
+          >
+            "og:description"
+          </span>
+           
+          <span
+            className="darkBlue"
+          >
+            content =
+          </span>
+          <span
+            className="blue"
+          >
+            "I think it might be the best website ever made."
+          </span>
+           
+          <span
+            className="darkBlue"
+          >
+            /&gt;
+          </span>
+          <br />
+                  
+          <span
+            className="darkBlue"
+          >
+            &lt;/&gt;
+          </span>
+          <br />
+                ),
+          <br />
+              
+          },
+          <br />
+            
+          },
+          <br />
+          }, {
+          <br />
+            
+          <span
+            className="darkBlue"
+          >
+            path
+          </span>
+          : 
+          <span
+            className="blue"
+          >
+            '/about'
+          </span>
+          ,
+          <br />
+            
+          <span
+            className="darkBlue"
+          >
+            Component
+          </span>
+          : 
+          <span
+            className="orange"
+          >
+            About
+          </span>
+          ,
+          <br />
+            
+          <span
+            className="darkBlue"
+          >
+            handle
+          </span>
+          : {
+          <br />
+              
+          <span
+            className="darkBlue"
+          >
+            head
+          </span>
+          : {
+          <br />
+                
+          <span
+            className="darkBlue"
+          >
+            title
+          </span>
+          : 
+          <span
+            className="blue"
+          >
+            'Some things about my website'
+          </span>
+          ,
+          <br />
+                
+          <span
+            className="darkBlue"
+          >
+            tags
+          </span>
+          : (
+          <br />
+                  
+          <span
+            className="darkBlue"
+          >
+            &lt;&gt;
+          </span>
+          <br />
+                    
+          <span
+            className="darkBlue"
+          >
+            &lt;
+          </span>
+          <span
+            className="green"
+          >
+            meta
+          </span>
+           
+          <span
+            className="darkBlue"
+          >
+            property =
+          </span>
+          <span
+            className="blue"
+          >
+            "og:title"
+          </span>
+           
+          <span
+            className="darkBlue"
+          >
+            content =
+          </span>
+          <span
+            className="blue"
+          >
+            "Learn about the best website"
+          </span>
+           
+          <span
+            className="darkBlue"
+          >
+            /&gt;
+          </span>
+          <br />
+                    
+          <span
+            className="darkBlue"
+          >
+            &lt;
+          </span>
+          <span
+            className="green"
+          >
+            meta
+          </span>
+           
+          <span
+            className="darkBlue"
+          >
+            property =
+          </span>
+          <span
+            className="blue"
+          >
+            "og:description"
+          </span>
+           
+          <span
+            className="darkBlue"
+          >
+            content =
+          </span>
+          <span
+            className="blue"
+          >
+            "10 reasons this site is best."
+          </span>
+           
+          <span
+            className="darkBlue"
+          >
+            /&gt;
+          </span>
+          <br />
+                  
+          <span
+            className="darkBlue"
+          >
+            &lt;/&gt;
+          </span>
+          <br />
+                ),
+          <br />
+              
+          },
+          <br />
+            
+          },
+          <br />
+          }];
+          <br />
+          <br />
+          <span
+            className="red"
+          >
+            export default
+          </span>
+           dataRoutes;
+        </p>
+      </div>
+      <p>
+        These 
+        <span
+          className="highlight"
+        >
+          title
+        </span>
+        s and 
+        <span
+          className="highlight"
+        >
+          tags
+        </span>
+         will be rendered into the document head only for their respective routes.
       </p>
     </article>
   </section>

--- a/pages/Documentation/index.tsx
+++ b/pages/Documentation/index.tsx
@@ -16,6 +16,7 @@ import StaticFiles from './StaticFiles';
 import ErrorBoundary from './ErrorBoundary';
 import Testing from './Testing';
 import ApplicationLayouts from './ApplicationLayouts';
+import RouteSpecificData from './RouteSpecificData';
 import PullRequestTemplate from './PullRequestTemplate';
 import GithubWorkflow from './GithubWorkflow';
 
@@ -91,6 +92,9 @@ function Documentation() {
             <InternalLink to="#Application-Layouts">Application Layouts</InternalLink>
           </li>
           <li>
+            <InternalLink to="#Route-Specific-Data">Route-Specific Data</InternalLink>
+          </li>
+          <li>
             <InternalLink to="#Pull-Request-Template">Pull Request Template</InternalLink>
           </li>
           <li>
@@ -107,6 +111,7 @@ function Documentation() {
       <ErrorBoundary />
       <Testing />
       <ApplicationLayouts />
+      <RouteSpecificData />
       <PullRequestTemplate />
       <GithubWorkflow />
 

--- a/pages/Documentation/styles.module.scss
+++ b/pages/Documentation/styles.module.scss
@@ -121,6 +121,10 @@ $indent-unit: map.get(var.$content, 'padding');
     color: map.get(var.$code-colors, 'darkBlue');
   }
 
+  .green {
+    color: map.get(var.$code-colors, 'green');
+  }
+
   .grey {
     color: map.get(var.$code-colors, 'grey');
   }


### PR DESCRIPTION
## Description
Linked to Issue: #126 
Add section to Documentation page "Route-Specific Data" that mirrors the content of `docs/README.md`. Minor grammatical and syntax fixes applied to the contents of `docs/README.md`.

## Changes
* Add property `green` to map `$code-colors` in `app/var.module.scss`
* Minor grammatical and syntax fixes to section "Route-Specific Data" in `docs/README.md`
* Create component `pages/Documentation/RouteSpecificData.tsx` which renders documentation that mirrors the section "Route-Specific Data" in `docs/README.md`
* Create link to, and render component `RouteSpecificData` in `pages/Documentation/index.tsx`

## Steps to QA
* Verify the changes to `docs/README.md` look good
* Pull down and switch to this branch
* Run the app and verify on the `/documentation` path in browser
  * The link to the section "Route-Specific Data" works
  * The section content looks good
  * The code blocks look good, and the copy button within the blocks copy the correct code snippets