### PR TITLE
Bump version to v1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "tamsui",
-  "version": "0.0.0",
+  "version": "v1.0.0",
   "description": "An Express/React universal application boilerplate",
-  "main": "index.js",
+  "main": "dist/index.js",
   "scripts": {
     "analyze": "webpack-bundle-analyzer stats.json",
     "analyze:dev": "run-s build:dev analyze",


### PR DESCRIPTION
## Description
Linked to Issue: #132 
Update the `package.json` version field to `v1.0.0`. Additionally, update the `main` field in `package.json` to "dist/index.js" to accurately reflect the build settings.

## Changes
* Update `package.json` fields
  * `version` - set to `v1.0.0`
  * `main` - set to `dist/index.js`

## Steps to QA
* Ensure no issues

## After merge
Retag v1.0.0 to this commit
