### PR TITLE
Update UI colors to be WCAG AA compliant

### DIFF
--- a/app/global.module.scss
+++ b/app/global.module.scss
@@ -24,7 +24,7 @@
 :global a:hover,
 :global a:focus,
 :global a:visited {
-  color: map.get(var.$colors, "blue");
+  color: map.get(var.$colors, "darkBlue");
   text-decoration: none;
   font-weight: bold;
 }

--- a/app/var.module.scss
+++ b/app/var.module.scss
@@ -11,6 +11,7 @@ $colors: (
   "orange": #FFC470,
   "red": #DD5746,
   "maroon": #8B322C,
+  "darkBlue": #005675,
 );
 
 $code-colors: (

--- a/app/var.module.scss
+++ b/app/var.module.scss
@@ -6,7 +6,7 @@ $breakpoint-small-max: 39.9375rem;
 $colors: (
   "black": #000,
   "white": #fff,
-  "grey": #949494,
+  "grey": #595959,
   "blue": #4793AF,
   "orange": #FFC470,
   "red": #DD5746,

--- a/app/var.module.scss
+++ b/app/var.module.scss
@@ -6,16 +6,16 @@ $breakpoint-small-max: 39.9375rem;
 $colors: (
   "black": #000,
   "white": #fff,
-  "grey": #595959,
+  "grey": #e8e8e8,
   "blue": #4793AF,
   "orange": #FFC470,
   "red": #DD5746,
   "maroon": #8B322C,
-  "darkBlue": #005675,
+  "darkBlue": #3D7D94,
 );
 
 $code-colors: (
-  "background": #434343,
+  "background": #161B22,
   "blue": #A5D6FF,
   "darkBlue": #79c0ff,
   "green": #7EE787,

--- a/pages/Documentation/styles.module.scss
+++ b/pages/Documentation/styles.module.scss
@@ -9,7 +9,7 @@ $indent-unit: map.get(var.$content, 'padding');
 
 .highlight {
   padding: calc(map.get(var.$content, 'padding') / 8) calc(map.get(var.$content, 'padding') / 4);
-  color: map.get(var.$colors, 'white');
+  color: map.get(var.$colors, 'black');
   border-radius: 0.25rem;
   background-color: map.get(var.$colors, 'grey');
 }


### PR DESCRIPTION
## Description
Linked to Issue: #154
Some of the text in the boilerplate UI do not meet the [WCAG AA standards for contrast](https://www.w3.org/TR/WCAG21/#contrast-minimum):
* Links
* Code blocks
* Highlights

This PR addresses this issue by adjusting the colors so that they meet the minimum requirements for AA compliance.

## Changes
* Style anchor links in `app/global.module.scss` to use `$colors.darkBlue`
* Update `app/var.module.scss`
  * Lighten `$colors.grey`
  * Add `$colors.darkBlue` for use in links
  * Darken `$code-colors.background`
* Change class `highlight` to have black-colored text in `pages/Documentation/styles.module.scss`

## Steps to QA
* Pull down and switch to this branch
* Run the app
* Using the [Wave browser extension](https://wave.webaim.org/extension/) in browser, verify no color contrast errors on any page of the site (`/`, `/documentation`, `/error`, and `/notfound`)
