### PR TITLE
Update component `Heading` aria-label to not contain word "Link"

### DIFF
--- a/app/components/Heading/__tests__/__snapshots__/index.test.js.snap
+++ b/app/components/Heading/__tests__/__snapshots__/index.test.js.snap
@@ -47,7 +47,7 @@ exports[`Heading component matches id snapshot 1`] = `
       H2 Heading with ID
     </h2>
     <a
-      aria-label="Link to this section: H2 Heading with ID"
+      aria-label="URL of this section: H2 Heading with ID"
       className="link"
       href="#FooBaz"
       id="FooBaz"

--- a/app/components/Heading/index.tsx
+++ b/app/components/Heading/index.tsx
@@ -68,7 +68,7 @@ function Heading({
                 id={id}
                 className={styles.link}
                 href={`#${id}`}
-                aria-label={`Link to this section: ${children}`}
+                aria-label={`URL of this section: ${children}`}
               >
                 <LinkIcon width="1.75rem" height="1.75rem" />
               </a>

--- a/pages/Documentation/__tests__/__snapshots__/index.test.js.snap
+++ b/pages/Documentation/__tests__/__snapshots__/index.test.js.snap
@@ -110,7 +110,7 @@ exports[`Documentation Page Component matches snapshot 1`] = `
           Starting a Project
         </h2>
         <a
-          aria-label="Link to this section: Starting a Project"
+          aria-label="URL of this section: Starting a Project"
           className="link"
           href="#Starting-a-Project"
           id="Starting-a-Project"
@@ -725,7 +725,7 @@ exports[`Documentation Page Component matches snapshot 1`] = `
           NPM Scripts
         </h2>
         <a
-          aria-label="Link to this section: NPM Scripts"
+          aria-label="URL of this section: NPM Scripts"
           className="link"
           href="#NPM-Scripts"
           id="NPM-Scripts"
@@ -2056,7 +2056,7 @@ exports[`Documentation Page Component matches snapshot 1`] = `
           Developing Locally
         </h2>
         <a
-          aria-label="Link to this section: Developing Locally"
+          aria-label="URL of this section: Developing Locally"
           className="link"
           href="#Developing-Locally"
           id="Developing-Locally"
@@ -2197,7 +2197,7 @@ exports[`Documentation Page Component matches snapshot 1`] = `
           Project Configurations
         </h3>
         <a
-          aria-label="Link to this section: Project Configurations"
+          aria-label="URL of this section: Project Configurations"
           className="link"
           href="#Project-Configurations"
           id="Project-Configurations"
@@ -2923,7 +2923,7 @@ exports[`Documentation Page Component matches snapshot 1`] = `
           Running the Application
         </h3>
         <a
-          aria-label="Link to this section: Running the Application"
+          aria-label="URL of this section: Running the Application"
           className="link"
           href="#Running-the-Application"
           id="Running-the-Application"
@@ -3002,7 +3002,7 @@ exports[`Documentation Page Component matches snapshot 1`] = `
           Project Directories
         </h3>
         <a
-          aria-label="Link to this section: Project Directories"
+          aria-label="URL of this section: Project Directories"
           className="link"
           href="#Project-Directories"
           id="Project-Directories"
@@ -3133,7 +3133,7 @@ exports[`Documentation Page Component matches snapshot 1`] = `
           Adding an Application Directory
         </h3>
         <a
-          aria-label="Link to this section: Adding an Application Directory"
+          aria-label="URL of this section: Adding an Application Directory"
           className="link"
           href="#Adding-an-Application-Directory"
           id="Adding-an-Application-Directory"
@@ -3383,7 +3383,7 @@ exports[`Documentation Page Component matches snapshot 1`] = `
           Static Files
         </h3>
         <a
-          aria-label="Link to this section: Static Files"
+          aria-label="URL of this section: Static Files"
           className="link"
           href="#Static-Files"
           id="Static-Files"
@@ -3526,7 +3526,7 @@ exports[`Documentation Page Component matches snapshot 1`] = `
           Error Boundary
         </h3>
         <a
-          aria-label="Link to this section: Error Boundary"
+          aria-label="URL of this section: Error Boundary"
           className="link"
           href="#Error-Boundary"
           id="Error-Boundary"
@@ -3846,7 +3846,7 @@ exports[`Documentation Page Component matches snapshot 1`] = `
           Testing
         </h3>
         <a
-          aria-label="Link to this section: Testing"
+          aria-label="URL of this section: Testing"
           className="link"
           href="#Testing"
           id="Testing"
@@ -3972,7 +3972,7 @@ exports[`Documentation Page Component matches snapshot 1`] = `
           Application Layouts
         </h3>
         <a
-          aria-label="Link to this section: Application Layouts"
+          aria-label="URL of this section: Application Layouts"
           className="link"
           href="#Application-Layouts"
           id="Application-Layouts"
@@ -4337,7 +4337,7 @@ exports[`Documentation Page Component matches snapshot 1`] = `
           Route-Specific Data
         </h3>
         <a
-          aria-label="Link to this section: Route-Specific Data"
+          aria-label="URL of this section: Route-Specific Data"
           className="link"
           href="#Route-Specific-Data"
           id="Route-Specific-Data"
@@ -5164,7 +5164,7 @@ exports[`Documentation Page Component matches snapshot 1`] = `
           Pull Request Template
         </h3>
         <a
-          aria-label="Link to this section: Pull Request Template"
+          aria-label="URL of this section: Pull Request Template"
           className="link"
           href="#Pull-Request-Template"
           id="Pull-Request-Template"
@@ -5287,7 +5287,7 @@ exports[`Documentation Page Component matches snapshot 1`] = `
           Github Workflow
         </h3>
         <a
-          aria-label="Link to this section: Github Workflow"
+          aria-label="URL of this section: Github Workflow"
           className="link"
           href="#Github-Workflow"
           id="Github-Workflow"
@@ -5364,7 +5364,7 @@ exports[`Documentation Page Component matches snapshot 1`] = `
           Building for Production
         </h2>
         <a
-          aria-label="Link to this section: Building for Production"
+          aria-label="URL of this section: Building for Production"
           className="link"
           href="#Building-for-Production"
           id="Building-for-Production"

--- a/pages/Home/__tests__/__snapshots__/index.test.js.snap
+++ b/pages/Home/__tests__/__snapshots__/index.test.js.snap
@@ -713,7 +713,7 @@ exports[`Home Component matches snapshot 1`] = `
             Mission Intent
           </h2>
           <a
-            aria-label="Link to this section: Mission Intent"
+            aria-label="URL of this section: Mission Intent"
             className="link"
             href="#Mission-Intent"
             id="Mission-Intent"
@@ -794,7 +794,7 @@ exports[`Home Component matches snapshot 1`] = `
             What Tamsui Is Not
           </h3>
           <a
-            aria-label="Link to this section: What Tamsui Is Not"
+            aria-label="URL of this section: What Tamsui Is Not"
             className="link"
             href="#What-Tamsui-Is-Not"
             id="What-Tamsui-Is-Not"
@@ -869,7 +869,7 @@ exports[`Home Component matches snapshot 1`] = `
             Tech Stack
           </h2>
           <a
-            aria-label="Link to this section: Tech Stack"
+            aria-label="URL of this section: Tech Stack"
             className="link"
             href="#Tech-Stack"
             id="Tech-Stack"
@@ -1087,7 +1087,7 @@ exports[`Home Component matches snapshot 1`] = `
             Usage
           </h2>
           <a
-            aria-label="Link to this section: Usage"
+            aria-label="URL of this section: Usage"
             className="link"
             href="#Usage"
             id="Usage"


### PR DESCRIPTION
## Description
Linked to Issue: #155 
It is recommended for aria-labels on anchor tags to not contain the word "Link" as screen readers will announce a link twice. This PR changes the aria label of the Heading anchor tag to remove that word.

## Changes
* Update `aria-label` text of anchor tag in `app/components/Heading/index.tsx`

## Steps to QA
* Ensure changes look good (aria copy)

## After merge
* Verify changes improve accessibility score in a [accessibility tester](https://accessibilitytest.org/) after this change is deployed
