### PR TITLE
NotFound page: Fix typo

### DIFF
--- a/pages/NotFound/__tests__/__snapshots__/index.test.js.snap
+++ b/pages/NotFound/__tests__/__snapshots__/index.test.js.snap
@@ -216,7 +216,7 @@ exports[`NotFound Component matches snapshot 1`] = `
   <p
     className="notFoundMessage"
   >
-    This page does not exit!
+    This page does not exist!
   </p>
   <p
     className="notFoundMessage"

--- a/pages/NotFound/index.tsx
+++ b/pages/NotFound/index.tsx
@@ -14,7 +14,7 @@ export default function NotFound(): React.ReactElement {
       </div>
       <h1 className={styles.notFoundHeading}>Page Not Found!</h1>
       <p className={styles.notFoundMessage}>
-        This page does not exit!
+        This page does not exist!
       </p>
       <p className={styles.notFoundMessage}>
         <Link to="/">Return to Home</Link>


### PR DESCRIPTION
## Description
Linked to Issue: #7
A typo was caught on the NotFound page and is fixed.

## Changes
* Fix a typo in `pages/NotFound/index.tsx`

## Steps to QA
* Verify the typo no longer exists
